### PR TITLE
Setting correct hashes for string constants

### DIFF
--- a/src-core-pp/string_utils.ml
+++ b/src-core-pp/string_utils.ml
@@ -13,7 +13,13 @@ open Base_types;;
 let fix_to_str_hashtbl : (fix_string, string) Hashtbl.t = Hashtbl.create 10;;
 let str_to_fix_hashtbl : (string, fix_string) Hashtbl.t = Hashtbl.create 10;;
 
-let fix_string_to_string fixstr = Hashtbl.find fix_to_str_hashtbl fixstr;;
+let fix_string_to_string fixstr = 
+    if not (Hashtbl.mem fix_to_str_hashtbl fixstr) then
+        ( match fixstr with
+            | Model_string hash -> failwith ( "Unrecognized model string \"" ^ string_of_int hash ^ "\".")
+            | Admin_string hash -> failwith ( "Unrecognized admin string \"" ^ string_of_int hash ^ "\".")
+        )
+    else Hashtbl.find fix_to_str_hashtbl fixstr;;
 
 let string_to_fix_string rawstr =
     if Hashtbl.mem str_to_fix_hashtbl rawstr then

--- a/src-protocol/full_messages.ml
+++ b/src-protocol/full_messages.ml
@@ -120,12 +120,12 @@ type fix_header = {
 ;;
 
 let default_fix_header = {
-    h_begin_string                    = Model_string 0;
+    h_begin_string                    = Admin_string 546607350; (* Hash of "FIX.4.4" *)
     h_body_length                     = 0;
     h_msg_seq_num                     = 0;
     h_poss_dup_flag                   = None;
-    h_target_comp_id                  = Model_string 1;
-    h_sender_comp_id                  = Model_string 2;
+    h_target_comp_id                  = Admin_string 183924456; (* Hash of "IMANDRA" *)
+    h_sender_comp_id                  = Admin_string 780720412; (* Hash of "TARGET"  *)
     h_on_behalf_of_comp_id            = None;
     h_deliver_to_comp_id              = None;
     h_secure_data_len                 = None;

--- a/src-protocol/full_messages.ml
+++ b/src-protocol/full_messages.ml
@@ -119,48 +119,11 @@ type fix_header = {
 }
 ;;
 
-let default_fix_header = {
-    h_begin_string                    = Admin_string 546607350; (* Hash of "FIX.4.4" *)
-    h_body_length                     = 0;
-    h_msg_seq_num                     = 0;
-    h_poss_dup_flag                   = None;
-    h_target_comp_id                  = Admin_string 183924456; (* Hash of "IMANDRA" *)
-    h_sender_comp_id                  = Admin_string 780720412; (* Hash of "TARGET"  *)
-    h_on_behalf_of_comp_id            = None;
-    h_deliver_to_comp_id              = None;
-    h_secure_data_len                 = None;
-    h_secure_data                     = None;
-    h_sender_sub_id                   = None;
-    h_sender_location_id              = None;
-    h_target_sub_id                   = None;
-    h_target_location_id              = None;
-    h_on_behalf_of_sub_id             = None;
-    h_on_behalf_of_location_id        = None;
-    h_deliver_to_sub_id               = None;
-    h_deliver_to_location_id          = None;
-    h_poss_resend                     = None;
-    h_sending_time                    = default_utctimestamp;
-    h_orig_sending_time               = None;
-    h_xml_data_len                    = None;
-    h_xml_data                        = None;
-    h_message_enconding               = None;
-    h_last_msg_seq_num_processed      = None;
-    h_no_hops                         = None;
-}
-;;
-
 (** Standard FIX trailer *)
 type fix_trailer = {
     signature_length                : int option;  (* Tag 93: Signature Length *)
     signature                       : int option;  (* Tag 89: Signature text *)
     check_sum                       : int;  (* Tag 10: *)
-}
-;;
-
-let default_fix_trailer = {
-    signature_length                = None;
-    signature                       = None;
-    check_sum                       = 0;
 }
 ;;
 

--- a/src/fix_engine_state.ml
+++ b/src/fix_engine_state.ml
@@ -128,8 +128,8 @@ let init_fix_engine_state = {
     fe_curr_mode            = NoActiveSession;              
     fe_curr_time            = make_utctimestamp ( 2017, 1, 1, 0, 1, 0, None );
 
-    fe_comp_id              = Model_string 1;
-    fe_target_comp_id       = Model_string 2;
+    fe_comp_id              = Admin_string 183924456; (* Hash of "IMANDRA" *)
+    fe_target_comp_id       = Admin_string 780720412; (* Hash of "TARGET"  *)
 
     incoming_int_msg        = None;                           
     outgoing_int_msg        = None;

--- a/src/fix_engine_utils.ml
+++ b/src/fix_engine_utils.ml
@@ -18,6 +18,14 @@ open Full_messages;;
 open Fix_engine_state;;
 (* @meta[imandra_ignore] off @end *)
 
+type session_details = {
+    constant_begin_string : fix_string
+};;
+
+let default_session_details = {
+    constant_begin_string = Admin_string 546607350 (* Hash of "FIX.4.4" *)
+};;
+
 (** Does the message have the right sequence number?
 
     This is when we need to transfer into Recovery Mode and request the 
@@ -107,19 +115,43 @@ let add_msg_to_history ( history, msg : full_valid_fix_msg list * full_valid_fix
 (** Create outbound FIX message with the appropriate header and trailer. *)
 let create_outbound_fix_msg ( osn, target_comp_id, our_comp_id, curr_time, msg, is_duplicate ) = {
     full_msg_header = {
-        default_fix_header with 
-            h_msg_seq_num = osn + 1;
-            h_poss_dup_flag = Some is_duplicate;
-            h_target_comp_id = target_comp_id;
-            h_sender_comp_id = our_comp_id;
-            h_sending_time   = curr_time
+        h_begin_string = default_session_details.constant_begin_string;
+        h_body_length = 0;
+        h_msg_seq_num = osn + 1;
+        h_poss_dup_flag = Some is_duplicate;
+        h_target_comp_id = target_comp_id;
+        h_sender_comp_id = our_comp_id;
+        h_sending_time   = curr_time;
+        h_on_behalf_of_comp_id            = None;
+        h_deliver_to_comp_id              = None;
+        h_secure_data_len                 = None;
+        h_secure_data                     = None;
+        h_sender_sub_id                   = None;
+        h_sender_location_id              = None;
+        h_target_sub_id                   = None;
+        h_target_location_id              = None;
+        h_on_behalf_of_sub_id             = None;
+        h_on_behalf_of_location_id        = None;
+        h_deliver_to_sub_id               = None;
+        h_deliver_to_location_id          = None;
+        h_poss_resend                     = None;
+        h_orig_sending_time               = None;
+        h_xml_data_len                    = None;
+        h_xml_data                        = None;
+        h_message_enconding               = None;
+        h_last_msg_seq_num_processed      = None;
+        h_no_hops                         = None;
     };
     
     (* We're simply attaching the message data here. *)
     full_msg_data = msg;
 
     (** Trailers would be augmented by raw OCaml printers/parsers. *)
-    full_msg_trailer = default_fix_trailer
+    full_msg_trailer = {
+        signature_length = None;
+        signature        = None;
+        check_sum        = 0;
+    }
 };;
 
 (** Create a logon message we would send out to initiate a connection 


### PR DESCRIPTION
Computed the values of the "IMANDRA", "TARGET" and "FIX.4.4" strings.

Removed default_header and default_trailer.

A session_details record contains the "FIX.4.4" string.

Also added a more informative exception for the unrecognized fix_string hashes.