### PR TITLE
Duplicate messages treatment logic.

### DIFF
--- a/src-protocol-pp/encode_admin_tags.ml
+++ b/src-protocol-pp/encode_admin_tags.ml
@@ -47,6 +47,7 @@ let encode_admin_field_tag = function
     | Full_Msg_RawData_Tag                 -> "96"  
     | Full_Msg_EncryptMethod_Tag           -> "98"  
     | Full_Msg_RefTagID_Tag                -> "371"  
+    | Full_Msg_OrigSendingTime_Tag         -> "122"
 ;;
 
 

--- a/src-protocol-pp/fix_engine_json.ml
+++ b/src-protocol-pp/fix_engine_json.ml
@@ -23,6 +23,7 @@ let fix_engine_mode_to_string = function
     | LogonInitiated                                    -> "LogonInitiated"
     | ActiveSession                                     -> "ActiveSession"
     | GapDetected                                       -> "GapDetected"
+    | ShuttingDown                                      -> "ShuttingDown"
     | Recovery                                          -> "Recovery"
     | Retransmit                                        -> "Retransmit"
     | ShutdownInitiated                                 -> "ShutdownInitiated"

--- a/src-protocol-pp/full_admin_tags_json.ml
+++ b/src-protocol-pp/full_admin_tags_json.ml
@@ -48,6 +48,7 @@ let full_admin_field_tag_to_string = function
     | Full_Msg_TestReqID_Tag             -> "TestReqID_Tag"
     | Full_Msg_Text_Tag                  -> "Text_Tag"
     | Full_Msg_Username_Tag              -> "Username_Tag"
+    | Full_Msg_OrigSendingTime_Tag       -> "OrigSendingTime_Tag"
 ;;
 
 (** *)

--- a/src-protocol/full_admin_tags.ml
+++ b/src-protocol/full_admin_tags.ml
@@ -45,5 +45,6 @@ type full_admin_field_tag =
     | Full_Msg_TestReqID_Tag 
     | Full_Msg_Text_Tag
     | Full_Msg_Username_Tag 
+    | Full_Msg_OrigSendingTime_Tag
 ;;
 

--- a/src/fix_engine.ml
+++ b/src/fix_engine.ml
@@ -215,6 +215,8 @@ let one_step ( engine : fix_engine_state ) =
     | GapDetected  -> run_gap_detected (engine)
     (** If we still need to retransmit our messages out to the receiving engine. *)
     | Retransmit   -> run_retransmit (engine)
+    (** We need to send out Logoff and transition to ShutdownInitiated *)
+    | ShuttingDown -> logoff_and_shutdown (engine)
     (** Now we look to process internal (coming from our application) and external (coming from
         another FIX engine) messages. *)
     | _ -> begin match engine.incoming_fix_msg with 

--- a/src/fix_engine_state.ml
+++ b/src/fix_engine_state.ml
@@ -61,12 +61,13 @@ type fix_engine_mode =
     | NoActiveSession       (** State of the engine before logon. *)
     | LogonInitiated        (** Middle of logon session. *)
     | ActiveSession         (** Application messages are now processed. *)
-    | GapDetected           (** Detected out-of-sequence message. Waiting to receive it. *)
-    | Recovery              (** RequestResend has been sent out. Waiting to recover the messages. *)
+    | GapDetected           (** Detected out-of-sequence message. Sending out ResendRequest. *)
+    | Recovery              (** RequestResend has been sent out. Waiting to recover the messages, filling int the cache.. *)
     | CacheReplay           (** Replaying the cache. *)
     | Retransmit            (** Retransmitting sequence of messages because we were asked to retransmit. *)
+    | ShuttingDown          (** We'll nees to send a logoff message adn transition to ShutdownInitiated. *)               
     | ShutdownInitiated     (** Shutting-down protocol. *)
-    | Error                 (** Received a non-dup message with earlier sequence number. *)
+    | Error                 (** *)
     | WaitingForHeartbeat   (** Sent out TestRequest message.  *)
 ;;
 
@@ -169,7 +170,7 @@ let engine_state_busy engine =
    ( engine.outgoing_fix_msg != None ) ||
    ( engine.outgoing_int_msg != None ) ||
    ( match engine.fe_curr_mode with
-        | GapDetected | CacheReplay | Retransmit -> true
+        | GapDetected | CacheReplay | Retransmit | ShuttingDown -> true
         | _ -> false
    )
 ;;

--- a/src/fix_engine_utils.ml
+++ b/src/fix_engine_utils.ml
@@ -15,6 +15,7 @@ open Full_admin_enums;;
 open Full_admin_messages;;
 open Full_app_messages;;
 open Full_messages;;
+open Full_message_tags;;
 open Fix_engine_state;;
 (* @meta[imandra_ignore] off @end *)
 
@@ -34,15 +35,6 @@ let default_session_details = {
 let msg_is_sequence_gap ( engine, msg_header : fix_engine_state * fix_header ) = 
     msg_header.h_msg_seq_num > engine.incoming_seq_num + 1
 ;;
-(** If sequence number is too low and the "possible duplicate" flag is not set,
-    then we'll need to teminate the connection. *)
-let msg_is_unexpected_duplicate ( engine, msg_header : fix_engine_state * fix_header ) = 
-    let seq_num_duplicate = msg_header.h_msg_seq_num < (engine.incoming_seq_num + 1) in 
-    match msg_header.h_poss_dup_flag with 
-    | Some true -> false
-    | Some false | None -> seq_num_duplicate
-;;
-
 
 (** get_gap_fill_msg -> out of all of the administrative messages, only the 'Reject' can be retransmitted.
     All application-level messages may be retransmitted - we should, in the future add logic to 
@@ -254,12 +246,12 @@ let create_session_reject_msg ( outbound_seq_num, target_comp_id, comp_id, curr_
         Full_FIX_Admin_Msg (
             Full_Msg_Reject {
                 sr_ref_seq_num              = reject_info.srej_msg_msg_seq_num;
-                sr_ref_tag_id               = None;
-                sr_ref_msg_type             = None;
+                sr_ref_tag_id               = reject_info.srej_msg_field_tag;
+                sr_ref_msg_type             = reject_info.srej_msg_msg_type;
                 sr_session_reject_reason    = reject_info.srej_msg_reject_reason;
-                sr_text                     = None;
-                sr_encoded_text_len         = None;
-                sr_encoded_text             = None
+                sr_text                     = reject_info.srej_text;
+                sr_encoded_text_len         = reject_info.srej_encoded_text_len;
+                sr_encoded_text             = reject_info.srej_encoded_text
             } ) in
     create_outbound_fix_msg ( outbound_seq_num, target_comp_id, comp_id, curr_time, msg_data, false )
 ;;
@@ -319,7 +311,7 @@ let session_reject ( rejected_data, engine : session_rejected_msg_data * fix_eng
             incoming_fix_msg        = None;
             fe_last_time_data_sent  = engine.fe_curr_time;
             outgoing_fix_msg        = Some ( ValidMsg ( reject_msg ));
-            incoming_seq_num        = rejected_data.srej_msg_msg_seq_num;
+            incoming_seq_num        = rejected_data.srej_msg_msg_seq_num + 1;
             outgoing_seq_num        = engine.outgoing_seq_num + 1;
             fe_history              = add_msg_to_history ( engine.fe_history, reject_msg );
         }
@@ -339,4 +331,39 @@ let hbeat_interval_null ( interval : fix_duration ) =
     field_null ( interval.dur_hours )   &&
     field_null ( interval.dur_minutes ) &&
     field_null ( interval.dur_seconds )
+;;
+
+
+(** Check the message header ( presence and value of the OrigSendingTime ) 
+    returns None if no problems are found. *)
+let validate_message_header ( engine, msg_header, msg_tag : fix_engine_state * fix_header * full_msg_tag ) = 
+    let reject = { (** No orig_sending_time => create session reject *)
+            srej_msg_msg_seq_num   = msg_header.h_msg_seq_num;
+            srej_msg_field_tag     = None;
+            srej_msg_msg_type      = Some msg_tag;
+            srej_msg_reject_reason = None;
+            srej_text              = None; 
+            srej_encoded_text_len  = None;
+            srej_encoded_text      = None;
+        } in
+    match msg_header.h_poss_dup_flag with Some false | None -> None | Some true ->
+    (** Message header has a PossibleDuplicate flag => must have orig_sending_time *)
+    match msg_header.h_orig_sending_time with 
+    | None -> 
+        let reject =  { reject with (** No orig_sending_time => create session reject *)
+            srej_msg_field_tag = Some (Full_Admin_Field_Tag Full_Msg_OrigSendingTime_Tag);
+            srej_msg_reject_reason = Some RequiredTagMissing; 
+            (** TODO: rejection fix_string here *)
+            } in
+        let engine = session_reject ( reject , engine ) in
+        Some engine
+    | Some orig_sending_time ->
+    if utctimestamp_LessThan (msg_header.h_sending_time, orig_sending_time ) then
+        let reject = { reject with (** The sending_time is less than orig_sending_time -- reject and logout *)
+            srej_msg_field_tag = Some (Full_Admin_Field_Tag Full_Msg_OrigSendingTime_Tag);
+            srej_msg_reject_reason = Some SendingTimeAccuracyProblem;
+            } in
+        let engine = session_reject ( reject , engine ) in
+        Some { engine with fe_curr_mode = ShuttingDown }
+    else None
 ;;


### PR DESCRIPTION
- Updated the logic wilt treatment of duplicate / possible duplicate messages. Most of the new checks are happening in the `validate_message_header` function.

 - Fixed a couple of problems with sequence numbers.

 - Session reject messages are now sending out the detailed information about which messagetype/tag was problematic.