### PR TITLE
Fixing parsing of non lenght=6 float fractionals

### DIFF
--- a/src-core-pp/parse_base_types.ml
+++ b/src-core-pp/parse_base_types.ml
@@ -34,15 +34,18 @@ let parse_bool ( str : string) : bool option =
     | _ -> None
 ;;
 
-(** Convert string to fix_float type. *)
-let parse_float (str: string) : fix_float_6 option =
+let rec pow10 n =
+    if n <= 0 then 1 else 10 * pow10 (n-1)
+
+let parse_float (str: string) : Numeric.fix_float_6 option =
     if String.get str 0 = '+' then None else
     let whole, tail = Scanf.sscanf str "%d%s" (fun w f -> (w,f)) in
     if (tail = "") || (tail = ".") then Some (Float_6 ( whole * 1000000 )) else
     if String.get tail 0 != '.' then None else
     let fraction = Scanf.sscanf tail ".%d" (fun t -> t) in
-    if (String.length tail - 1) <= 6 then
-    Some (Float_6 (whole * 10000 + fraction))
+    let frlen = String.length tail - 1 in
+    if frlen <= 6 then
+    Some (Float_6 (whole * 1000000 + fraction * pow10 (6 - frlen)))
     else None
 ;;
 


### PR DESCRIPTION
```
[ "42." ; "0.42" ; "0.1"; "0.001"; "0.0001"; "0.0"; "0.000001"] 
|> List.map parse_float 
|> List.map (function Some x -> x) 
|> List.map Encode_base_types.encode_float_6;;

- : string list =
["42.000000"; "0.420000"; "0.100000"; "0.001000"; "0.000100"; "0.000000";"0.000001"]
```