### PR TITLE
Ewen/removing json annotations

### DIFF
--- a/src-core-pp/base_types_json.iml
+++ b/src-core-pp/base_types_json.iml
@@ -19,9 +19,9 @@ open D.Infix;;
   *  Int
 *)
 
-let int_to_json x : json = `Int (Z.to_int x) ;;
+let int_to_json x  = `Int (Z.to_int x) ;;
 
-let int_opt_to_json : int option -> json = function
+let int_opt_to_json  = function
   | None   -> `Null
   | Some x -> int_to_json x
 ;;
@@ -47,7 +47,7 @@ let char_decoder : string Decoders_yojson.Basic.Decode.decoder =
   *  FIX_Float
 *)
 
-let float_0_to_json : fix_float_0 -> json = function
+let float_0_to_json  = function
   | Float_0 x ->
     `Assoc
       [ ( "Precision", `Int (Z.to_int 0) )
@@ -68,7 +68,7 @@ let float_0_decoder : Numeric.fix_float_0 Decoders_yojson.Basic.Decode.decoder =
     D.succeed 
       Numeric.(float_Create_0 (Z.of_int x));;
 
-let float_1_to_json : fix_float_1 -> json = function
+let float_1_to_json  = function
   | Float_1 x ->
     `Assoc
       [ ( "Precision", `Int (Z.to_int 1) )
@@ -89,7 +89,7 @@ let float_1_decoder : Numeric.fix_float_1 Decoders_yojson.Basic.Decode.decoder =
     D.succeed 
       Numeric.(float_Create_1 x);;
 
-let float_2_to_json : fix_float_2 -> json = function
+let float_2_to_json  = function
   | Float_2 x ->
     `Assoc
       [ ( "Precision", `Int (Z.to_int 2) )
@@ -111,7 +111,7 @@ let float_2_decoder : Numeric.fix_float_2 Decoders_yojson.Basic.Decode.decoder =
       Numeric.(float_Create_2 x);;
 
 
-let float_3_to_json : fix_float_3 -> json = function
+let float_3_to_json  = function
   | Float_3 x ->
     `Assoc
       [ ( "Precision", `Int (Z.to_int 3) )
@@ -133,7 +133,7 @@ let float_3_decoder : Numeric.fix_float_3 Decoders_yojson.Basic.Decode.decoder =
       Numeric.(float_Create_3 x);;
 
 
-let float_4_to_json : fix_float_4 -> json = function
+let float_4_to_json = function
   | Float_4 x ->
     `Assoc
       [ ( "Precision", `Int (Z.to_int 4))
@@ -155,7 +155,7 @@ let float_4_decoder : Numeric.fix_float_4 Decoders_yojson.Basic.Decode.decoder =
       Numeric.(float_Create_4 x);;
 
 
-let float_5_to_json : fix_float_5-> json = function
+let float_5_to_json  = function
   | Float_5 x ->
     `Assoc
       [ ( "Precision", `Int (Z.to_int 5))
@@ -177,7 +177,7 @@ let float_5_decoder : Numeric.fix_float_5 Decoders_yojson.Basic.Decode.decoder =
       Numeric.(float_Create_5 x);;
 
 
-let float_6_to_json : fix_float_6 -> json = function
+let float_6_to_json  = function
   | Float_6 x ->
     `Assoc
       [ ( "Precision", `Int (Z.to_int 6))
@@ -209,7 +209,7 @@ let float_decoder = float_6_decoder;;
   FIX_String
 *)
 
-let string_to_json x : json = 
+let string_to_json x  = 
   `String  x  
 ;;
 
@@ -227,7 +227,7 @@ let string_decoder : string Decoders_yojson.Basic.Decode.decoder =
   *  FIX_Symbol
 *)
 
-let symbol_to_json x : json = 
+let symbol_to_json x  = 
   `String x  
 ;;
 
@@ -245,7 +245,7 @@ let symbol_decoder : string Decoders_yojson.Basic.Decode.decoder =
   *  FIX_Bool
 *)
 
-let bool_to_json : bool -> json = function
+let bool_to_json  = function
   | true  -> `Bool true 
   | false -> `Bool false 
 ;;
@@ -253,7 +253,7 @@ let bool_to_json : bool -> json = function
 let bool_decoder : bool Decoders_yojson.Basic.Decode.decoder =
   D.bool;;
 
-let bool_opt_to_json : bool option -> json = function
+let bool_opt_to_json  = function
   | None   -> `Null
   | Some x -> bool_to_json x 
 ;;

--- a/src-core-pp/datetime_json.iml
+++ b/src-core-pp/datetime_json.iml
@@ -22,7 +22,7 @@ let filter_nulls =
   List.filter (function ( _, `Null ) -> false | _ -> true )
 ;;
 
-let utctimestamp_milli_to_json ( ts : fix_utctimestamp_milli ) : json =
+let utctimestamp_milli_to_json ( ts : fix_utctimestamp_milli )  =
   let list_assoc = [
     ( "utc_timestamp_year"     , int_to_json ts.utc_timestamp_year                     );
     ( "utc_timestamp_month"    , int_to_json ts.utc_timestamp_month                    );
@@ -53,7 +53,7 @@ let utctimestamp_milli_decoder : fix_utctimestamp_milli Decoders_yojson.Basic.De
   ; utc_timestamp_millisec
   };;
 
-let utctimestamp_micro_to_json ( ts : fix_utctimestamp_micro ) : json =
+let utctimestamp_micro_to_json ( ts : fix_utctimestamp_micro )  =
   let list_assoc = [
     ( "utc_timestamp_year"     , int_to_json ts.utc_timestamp_year                     );
     ( "utc_timestamp_month"    , int_to_json ts.utc_timestamp_month                    );

--- a/src-core-pp/datetime_json.iml
+++ b/src-core-pp/datetime_json.iml
@@ -18,8 +18,8 @@ open D.Infix;;
 
 
 
-let filter_nulls =
-  List.filter (function ( _, `Null ) -> false | _ -> true )
+let filter_nulls x =
+  List.filter (function ( _, `Null ) -> false | _ -> true ) x
 ;;
 
 let utctimestamp_milli_to_json ( ts : fix_utctimestamp_milli )  =


### PR DESCRIPTION
removing src-core-pp json annotations to allow to fit into any json return type with defined polymorphic type constructors