### PR TITLE
Ewen/adding ipl decoder

### DIFF
--- a/itr_ast/dune
+++ b/itr_ast/dune
@@ -1,6 +1,6 @@
 (library
   (name itr_ast)
-  (public_name fix-engine.itr-ast)
+  (public_name fix-engine.itr_ast)
   (wrapped false)
   (flags :standard -open Imandra_prelude -warn-error -A+8+39 -alert -deprecated -w -33-58)
   (libraries types_pp imandra-prelude containers decoders decoders-yojson yojson core core_pp)

--- a/itr_ast/dune
+++ b/itr_ast/dune
@@ -1,0 +1,7 @@
+(library
+  (name itr_ast)
+  (public_name fix-engine.itr-ast)
+  (wrapped false)
+  (flags :standard -open Imandra_prelude -warn-error -A+8+39 -alert -deprecated -w -33-58)
+  (libraries types_pp imandra-prelude containers decoders decoders-yojson yojson core core_pp)
+)

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -126,7 +126,7 @@ type literal =
   | UnquotedString of string
   | Float of real
   | Coll of expr list
-  | MapColl of (expr*expr) list
+  | MapColl of expr * ((expr*expr) list)
   | LiteralNone
   | LiteralSome of expr
   | Datetime of datetime

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -604,7 +604,7 @@ type instruction =
   | Message of {name:string;fields:field list}
   | Set of
       { prop : string
-      ; value : expr
+      ; value : record_item
       }
   | Unset of value
   | Call of
@@ -726,8 +726,10 @@ module Value = struct
         exists f v
     | ExpectingOf { variable = _; expecting = { exprs = es; modifier = _ } } ->
         CCList.exists (exists_expr f) es
-    | Print e | Run e | Sleep e | Assert e | Set { prop = _; value = e } ->
+    | Print e | Run e | Sleep e | Assert e ->
         exists_expr f e
+    | Set { prop = _; value = e } ->
+        exists_record_item f e
     | Fail e | Return e | Connect { connection = _; timeout = e; block = _ } ->
         e |> CCOpt.exists (exists_expr f)
     | Action {fields;_} ->
@@ -761,7 +763,7 @@ module Value = struct
         || CCList.exists (exists_instruction f) else_
 end
 
-let append ~to_ e = Set { prop = to_; value = add (var to_) e }
+let append ~to_ e = Set { prop = to_; value = Rec_value (add (Value (Record_item (Rec_value (var to_)))) e )}
 
 (** Combine:
 
@@ -776,17 +778,17 @@ let rec combine_appends ~var = function
   | Set { prop = x1; value }
     :: Set
          { prop = x2
-         ; value = Add { lhs = Value (Variable (Var x3)); rhs; op = '+' }
+         ; value = Rec_value (Add { lhs = Value (Variable (Var x3)); rhs; op = '+' })
          }
        :: is
     when x1 = var && x2 = var && x3 = var ->
       let i =
         match value with
-        | Add { lhs = Value (Variable (Var x4)); rhs = value; op = '+' }
+        | Rec_value (Add { lhs = Value (Variable (Var x4)); rhs = value; op = '+' })
           when x4 = var ->
             append ~to_:var (add_eval value rhs)
         | _ ->
-            Set { prop = var; value = add value rhs }
+            Set { prop = var; value = Rec_value (add (Value (Record_item value)) rhs) }
       in
       combine_appends ~var (i :: is)
   | i :: is ->

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -125,6 +125,7 @@ type literal =
   | UnquotedString of string
   | Float of real
   | Coll of expr list
+  | MapColl of (expr*expr) list
   | LiteralNone
   | Datetime of datetime
 

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -197,7 +197,9 @@ and record_item =
   | Rec_value of expr
   | Rec_record of record
   | Rec_repeating_group of
-      { num_in_group_field : string
+      {name: string
+      ; message_template: string option
+      ; num_in_group_field : string
       ; elements : record list
       }
 
@@ -299,9 +301,9 @@ let map_record_item ~map_expr ~map_record = function
       Rec_value (map_expr expr)
   | Rec_record record ->
       Rec_record (map_record record)
-  | Rec_repeating_group { num_in_group_field; elements } ->
+  | Rec_repeating_group { num_in_group_field; elements; name; message_template } ->
       Rec_repeating_group
-        { num_in_group_field; elements = CCList.map map_record elements }
+        { num_in_group_field; name; message_template; elements = CCList.map map_record elements }
 
 
 let map_record ~map_record_item r = String_map.map map_record_item r

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -203,10 +203,6 @@ and record_item =
       ; elements : record list
       }
 
-type field = {
-        name:string;
-        value: record_item
-}
 
 let rec expr_eq e1 e2 =
   match (e1, e2) with

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -200,6 +200,11 @@ and record_item =
       ; elements : record list
       }
 
+type field = {
+        name:string;
+        value: record_item
+}
+
 let rec expr_eq e1 e2 =
   match (e1, e2) with
   | Value v1, Value v2 ->

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -600,6 +600,7 @@ type instruction =
       }
   | Disconnect of Connection_ref.t
   | Action of {name:string;fields:field list}
+  | Message of {name:string;fields:field list}
   | Set of
       { prop : string
       ; value : expr
@@ -728,6 +729,8 @@ module Value = struct
     | Fail e | Return e | Connect { connection = _; timeout = e; block = _ } ->
         e |> CCOpt.exists (exists_expr f)
     | Action {fields;_} ->
+        CCList.exists (exists_record_item f) (List.map (fun x -> x.value) fields)
+    | Message {fields;_} ->
         CCList.exists (exists_record_item f) (List.map (fun x -> x.value) fields)
     | Send
         { variable = _

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -578,6 +578,11 @@ type expecting =
   ; exprs : expr list
   }
 
+type field =
+ { name: string
+ ; value : expr
+ }
+
 type instruction =
   | Break
   | Print of expr

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -644,6 +644,7 @@ type instruction =
       ; timeout : expr option
       ; where : expr
       ; expecting : expecting option
+      ; example : record
       }
   | IfThenElse of
       { cond : expr
@@ -748,7 +749,7 @@ module Value = struct
         CCList.exists (exists_instruction f) is
     | ForEach { dataset = e; instructions = is } ->
         exists_expr f e || CCList.exists (exists_instruction f) is
-    | Receive { variable = _; connection = _; timeout; where; expecting } ->
+    | Receive { variable = _; connection = _; timeout; where; expecting;_ } ->
         CCOpt.exists (exists_expr f) timeout
         || exists_expr f where
         || CCOpt.exists
@@ -895,8 +896,8 @@ let send ?variable ~template ~to_ ?using ?values () =
 
 let expecting ?modifier exprs = { modifier; exprs }
 
-let receive ?variable ~from ?timeout ~where ?expecting () =
-  Receive { variable; connection = from; timeout; where; expecting }
+let receive ?variable ~from ?timeout ~where ?expecting ~example () =
+  Receive { variable; connection = from; timeout; where; expecting; example }
 
 
 let expectingOf ~variable ~expecting = ExpectingOf { variable; expecting }

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -580,7 +580,7 @@ type expecting =
 
 type field =
  { name: string
- ; value : expr
+ ; value : record_item
  }
 
 type instruction =

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -1,6 +1,6 @@
 (* Imandra Inc. copyright 2021 *)
 [@@@program]
-
+[@@@import "../src-core/datetime.iml"]
 module Map_extra (M : CCMap.S) = struct
   include M
 

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -191,7 +191,7 @@ and expr =
       ; rhs : expr
       }
 
-and record = record_item String_map.t
+and record = {name:string;elements:record_item String_map.t}
 
 and record_item =
   | Rec_value of expr
@@ -251,14 +251,14 @@ and record_item_eq i1 i2 =
       expr_eq e1 e2
   | Rec_record r1, Rec_record r2 ->
       record_eq r1 r2
-  | ( Rec_repeating_group { num_in_group_field = n1; elements = elements1 }
-    , Rec_repeating_group { num_in_group_field = n2; elements = elements2 } ) ->
-      n1 = n2 && CCList.equal record_eq elements1 elements2
+  | ( Rec_repeating_group { name = nm1; num_in_group_field = n1; elements = elements1;_ }
+    , Rec_repeating_group { name = nm2; num_in_group_field = n2; elements = elements2;_ } ) ->
+      nm1 = nm2 && n1 = n2 && CCList.equal record_eq elements1 elements2
   | _ ->
       false
 
 
-and record_eq r1 r2 = String_map.equal record_item_eq r1 r2
+and record_eq r1 r2 = r1.name = r2.name && String_map.equal record_item_eq r1.elements r2.elements
 
 let map_value ~map_expr ~map_record_item = function
   | ObjectProperty { obj; index; prop } ->
@@ -306,7 +306,7 @@ let map_record_item ~map_expr ~map_record = function
         { num_in_group_field; name; message_template; elements = CCList.map map_record elements }
 
 
-let map_record ~map_record_item r = String_map.map map_record_item r
+let map_record ~map_record_item r = {name = r.name; elements = String_map.map map_record_item r.elements}
 
 let map f =
   let rec mri item =
@@ -479,16 +479,16 @@ let convert_timestamp_localmktdate date =
 
 let convert_timestamp_dateonly date = funcall "timestamp_to_dateonly" [ date ]
 
-let empty_record : record = String_map.empty
+let empty_record : record = {name = "";elements = String_map.empty}
 
 let rec map_value_in_record (path : string list) f (record : record) =
   match path with
   | [] ->
       record
   | [ field ] ->
-      record |> String_map.update field f
+      {name = record.name;elements = record.elements |> String_map.update field f}
   | field :: path ->
-      record
+      {name= record.name;elements = record.elements
       |> String_map.update field (fun entry ->
              let record =
                match entry with
@@ -497,7 +497,7 @@ let rec map_value_in_record (path : string list) f (record : record) =
                | _ ->
                    empty_record
              in
-             Some (Rec_record (map_value_in_record path f record)))
+             Some (Rec_record (map_value_in_record path f record)))}
 
 
 (** Given a record, return a list of paths to expressions that reference all the
@@ -518,7 +518,7 @@ let rec map_value_in_record (path : string list) f (record : record) =
 *)
 let rec flatten_record ?qualify_records (r : record) : (string list * expr) list
     =
-  r
+  r.elements
   |> String_map.to_list
   |> CCList.flat_map (fun (field, (item : record_item)) ->
          flatten_record_item ?qualify_records field item)
@@ -532,7 +532,7 @@ and flatten_record_item ?(qualify_records = true) field (i : record_item) =
       flatten_record ~qualify_records record
       |> CCList.map (fun (path, expr) ->
              if qualify_records then (field :: path, expr) else (path, expr))
-  | Rec_repeating_group { num_in_group_field; elements } ->
+  | Rec_repeating_group { num_in_group_field; elements;_ } ->
       elements
       |> CCList.mapi (fun i record ->
              flatten_record ~qualify_records record
@@ -706,12 +706,12 @@ module Value = struct
         exists_expr f e
     | Rec_record record ->
         exists_record f record
-    | Rec_repeating_group { num_in_group_field = _; elements } ->
+    | Rec_repeating_group { num_in_group_field = _; elements;_ } ->
         CCList.exists (exists_record f) elements
 
 
-  and exists_record f =
-    String_map.exists (fun _ record_item -> exists_record_item f record_item)
+  and exists_record f r =
+    String_map.exists (fun _ record_item -> exists_record_item f record_item) r.elements
 
 
   let rec exists_instruction f = function

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -1,0 +1,888 @@
+(* Imandra Inc. copyright 2021 *)
+[@@@program]
+
+module Map_extra (M : CCMap.S) = struct
+  include M
+
+  let merge_keep_left m1 m2 =
+    merge_safe m1 m2 ~f:(fun _ -> function
+      | `Left a -> Some a | `Right b -> Some b | `Both (a, _) -> Some a)
+
+
+  let merge_all_keep_left = function
+    | [] ->
+        empty
+    | m :: ms ->
+        CCList.fold_left merge_keep_left m ms
+end
+
+module String_map = Map_extra (CCMap.Make (CCString))
+
+let pp_string fmt s = CCFormat.(fprintf fmt "%S" s)
+
+module Var = struct
+  type t = Var of string
+
+  let mk v = Var v
+
+  let name (Var v) = v
+
+  let pp fmt =
+    let open CCFormat in
+    function Var v -> fprintf fmt "$%s" v
+end
+
+module Message_value = struct
+  type t =
+    { var : Var.t option
+    ; field_path : (string * int option) list
+    }
+
+  let mk ~var field_path = { var; field_path }
+
+  let to_json t : Yojson.Basic.t =
+    let pre : Yojson.Basic.t =
+      match t.var with None -> `Null | Some v -> `String (Var.name v)
+    in
+    let post : string * Yojson.Basic.t =
+      ( "field_path"
+      , `List
+          (List.map
+             (fun (x, o) ->
+               `Assoc
+                 [ ("name", `String x)
+                 ; ( "index"
+                   , match o with None -> `Null | Some x -> `Int (Z.to_int x) )
+                 ])
+             t.field_path) )
+    in
+    let ent = [ ("var_name", pre); post ] in
+    `Assoc ent
+
+
+  let pp fmt t =
+    let open CCFormat in
+    let index_pp fmt = function
+      | s, None ->
+          fprintf fmt "%s" s
+      | s, Some index ->
+          fprintf fmt "%s[%i]" s (Z.to_int index)
+    in
+    let pp_var_opt fmt = function
+      | None ->
+          ()
+      | Some v ->
+          fprintf fmt "%a." Var.pp v
+    in
+    fprintf
+      fmt
+      "%a%a"
+      pp_var_opt
+      t.var
+      (list ~sep:(return ".") index_pp)
+      t.field_path
+end
+
+module Connection_ref = struct
+  type t =
+    | String of string
+    | Var of Var.t
+
+  let string s = String s
+
+  let var v = Var (Var.mk v)
+
+  let to_json t =
+    match t with
+    | String s ->
+        `Assoc [ ("string", `String s) ]
+    | Var v ->
+        `Assoc [ ("var", `String (Var.name v)) ]
+
+
+  let pp fmt t =
+    let open CCFormat in
+    let pp_inner fmt = function
+      | String s ->
+          pp_string fmt s
+      | Var v ->
+          Var.pp fmt v
+    in
+    fprintf fmt "[%a]" pp_inner t
+end
+
+type datetime =
+  | UTCTimestamp of Datetime.fix_utctimestamp_micro
+  | UTCTimeOnly of Datetime.fix_utctimeonly_micro
+  | UTCDateOnly of Datetime.fix_utcdateonly
+  | LocalMktDate of Datetime.fix_localmktdate
+  | MonthYear of Datetime.fix_monthyear
+
+type literal =
+  | Bool of bool
+  | Int of int
+  | String of string
+  | UnquotedString of string
+  | Float of real
+  | Coll of expr list
+  | LiteralNone
+  | Datetime of datetime
+
+and value =
+  | Literal of literal
+  | Variable of Var.t
+  | MessageValue of Message_value.t
+  | ConnectionRef of Connection_ref.t
+  | TODOHex of string
+  | Now
+  | Counter
+  | ObjectProperty of
+      { obj : expr
+      ; index : int option
+      ; prop : string
+      }
+  | Funcall of
+      { func : string
+      ; args : expr list
+      }
+  | Record_item of record_item
+
+and expr =
+  | Value of value
+  | Not of expr
+  | In of
+      { el : expr
+      ; set : expr
+      }
+  | Arrow of
+      { condition : expr
+      ; assertion : expr
+      }
+  | Or of
+      { lhs : expr
+      ; rhs : expr
+      }
+  | And of
+      { lhs : expr
+      ; rhs : expr
+      }
+  | Eq of
+      { lhs : expr
+      ; rhs : expr
+      }
+  | Like of
+      { lhs : expr
+      ; rhs : expr
+      }
+  | Cmp of
+      { lhs : expr
+      ; op : string
+      ; rhs : expr
+      }
+  | Add of
+      { lhs : expr
+      ; op : char
+      ; rhs : expr
+      }
+  | Mul of
+      { lhs : expr
+      ; op : char
+      ; rhs : expr
+      }
+
+and record = record_item String_map.t
+
+and record_item =
+  | Rec_value of expr
+  | Rec_record of record
+  | Rec_repeating_group of
+      { num_in_group_field : string
+      ; elements : record list
+      }
+
+let rec expr_eq e1 e2 =
+  match (e1, e2) with
+  | Value v1, Value v2 ->
+      value_eq v1 v2
+  | Not e1, Not e2 ->
+      expr_eq e1 e2
+  | ( Arrow { condition = c1; assertion = a1 }
+    , Arrow { condition = c2; assertion = a2 } ) ->
+      expr_eq c1 c2 && expr_eq a1 a2
+  | Or { lhs = lhs1; rhs = rhs1 }, Or { lhs = lhs2; rhs = rhs2 }
+  | And { lhs = lhs1; rhs = rhs1 }, And { lhs = lhs2; rhs = rhs2 }
+  | Eq { lhs = lhs1; rhs = rhs1 }, Eq { lhs = lhs2; rhs = rhs2 }
+  | Like { lhs = lhs1; rhs = rhs1 }, Like { lhs = lhs2; rhs = rhs2 } ->
+      expr_eq lhs1 lhs2 && expr_eq rhs1 rhs2
+  | ( Cmp { lhs = lhs1; rhs = rhs1; op = op1 }
+    , Cmp { lhs = lhs2; rhs = rhs2; op = op2 } ) ->
+      op1 = op2 && expr_eq lhs1 lhs2 && expr_eq rhs1 rhs2
+  | ( Add { lhs = lhs1; rhs = rhs1; op = op1 }
+    , Add { lhs = lhs2; rhs = rhs2; op = op2 } )
+  | ( Mul { lhs = lhs1; rhs = rhs1; op = op1 }
+    , Mul { lhs = lhs2; rhs = rhs2; op = op2 } ) ->
+      op1 = op2 && expr_eq lhs1 lhs2 && expr_eq rhs1 rhs2
+  | _ ->
+      false
+
+
+and value_eq v1 v2 =
+  match (v1, v2) with
+  | Record_item i1, Record_item i2 ->
+      record_item_eq i1 i2
+  | ( Funcall { func = func1; args = args1 }
+    , Funcall { func = func2; args = args2 } ) ->
+      func1 = func2 && CCList.equal expr_eq args1 args2
+  | _ ->
+      v1 = v2
+
+
+and record_item_eq i1 i2 =
+  match (i1, i2) with
+  | Rec_value e1, Rec_value e2 ->
+      expr_eq e1 e2
+  | Rec_record r1, Rec_record r2 ->
+      record_eq r1 r2
+  | ( Rec_repeating_group { num_in_group_field = n1; elements = elements1 }
+    , Rec_repeating_group { num_in_group_field = n2; elements = elements2 } ) ->
+      n1 = n2 && CCList.equal record_eq elements1 elements2
+  | _ ->
+      false
+
+
+and record_eq r1 r2 = String_map.equal record_item_eq r1 r2
+
+let map_value ~map_expr ~map_record_item = function
+  | ObjectProperty { obj; index; prop } ->
+      ObjectProperty { obj = map_expr obj; index; prop }
+  | Funcall { func; args } ->
+      Funcall { func; args = CCList.map map_expr args }
+  | Record_item record_item ->
+      Record_item (map_record_item record_item)
+  | v ->
+      v
+
+
+let map_expr ~map_expr:f ~map_value = function
+  | Value v ->
+      Value (map_value v)
+  | Not e ->
+      Not (f e)
+  | Arrow { condition; assertion } ->
+      Arrow { condition = f condition; assertion = f assertion }
+  | Or { lhs; rhs } ->
+      Or { lhs = f lhs; rhs = f rhs }
+  | And { lhs; rhs } ->
+      And { lhs = f lhs; rhs = f rhs }
+  | Eq { lhs; rhs } ->
+      Eq { lhs = f lhs; rhs = f rhs }
+  | Like { lhs; rhs } ->
+      Like { lhs = f lhs; rhs = f rhs }
+  | Cmp { lhs; op; rhs } ->
+      Cmp { lhs = f lhs; op; rhs = f rhs }
+  | Add { lhs; op; rhs } ->
+      Add { lhs = f lhs; op; rhs = f rhs }
+  | Mul { lhs; op; rhs } ->
+      Mul { lhs = f lhs; op; rhs = f rhs }
+  | In { el; set } ->
+      In { el = f el; set = f set }
+
+
+let map_record_item ~map_expr ~map_record = function
+  | Rec_value expr ->
+      Rec_value (map_expr expr)
+  | Rec_record record ->
+      Rec_record (map_record record)
+  | Rec_repeating_group { num_in_group_field; elements } ->
+      Rec_repeating_group
+        { num_in_group_field; elements = CCList.map map_record elements }
+
+
+let map_record ~map_record_item r = String_map.map map_record_item r
+
+let map f =
+  let rec mri item =
+    map_record_item
+      ~map_expr:f
+      ~map_record:(map_record ~map_record_item:mri)
+      item
+  in
+  map_expr ~map_expr:f ~map_value:(map_value ~map_expr:f ~map_record_item:mri)
+
+
+let rec walk f e =
+  let e = f e in
+  map (walk f) e
+
+
+exception Iterated
+
+let iterated () = raise Iterated
+
+let iter f e =
+  try
+    ignore
+      (walk
+         (fun e ->
+           f e ;
+           e)
+         e)
+  with
+  | Iterated ->
+      ()
+
+
+let exists f e =
+  let found = ref false in
+  iter
+    (fun e ->
+      if f e
+      then (
+        found := true ;
+        iterated () ))
+    e ;
+  !found
+
+
+let rec fold f init e =
+  let init = f init e in
+  match e with
+  | Value _ ->
+      init
+  | Not e1 ->
+      fold f init e1
+  | Arrow { condition; assertion } ->
+      let init = fold f init condition in
+      fold f init assertion
+  | Or { lhs; rhs }
+  | And { lhs; rhs }
+  | Eq { lhs; rhs }
+  | Like { lhs; rhs }
+  | Cmp { lhs; rhs; _ }
+  | Add { lhs; rhs; _ }
+  | Mul { lhs; rhs; _ } ->
+      let init = fold f init lhs in
+      let init = fold f init rhs in
+      init
+  | In { el; set } ->
+      let init = fold f init el in
+      let init = fold f init set in
+      init
+
+
+let is_funcall = function Value (Funcall _) -> true | _ -> false
+
+let bool b = Value (Literal (Bool b))
+
+let string s = Value (Literal (String s))
+
+let unquoted_string s = Value (Literal (UnquotedString s))
+
+let int i = Value (Literal (Int i))
+
+let var v = Value (Variable (Var.mk v))
+
+let connection_ref c = Value (ConnectionRef c)
+
+let object_property obj ?index prop =
+  Value (ObjectProperty { obj; index; prop })
+
+
+let message_value ?var field_path =
+  Value
+    (MessageValue
+       { var; field_path = field_path |> CCList.map (fun f -> (f, None)) })
+
+
+let funcall func args = Value (Funcall { func; args })
+
+let and_ lhs rhs = And { lhs; rhs }
+
+let or_ lhs rhs = Or { lhs; rhs }
+
+let gt lhs rhs = Cmp { lhs; op = ">"; rhs }
+
+let add lhs rhs = Add { lhs; rhs; op = '+' }
+
+let sub lhs rhs = Add { lhs; rhs; op = '-' }
+
+let is_set e = funcall "IsSet" [ e ]
+
+let eq lhs rhs = Eq { lhs; rhs }
+
+let eq_opt lhs rhs =
+  or_ (and_ (Not (is_set lhs)) (Not (is_set rhs))) (eq lhs rhs)
+
+
+let add_eval lhs rhs =
+  match (lhs, rhs) with
+  | Value (Literal (String lhs)), Value (Literal (String rhs)) ->
+      Value (Literal (String (lhs ^ rhs)))
+  | _ ->
+      add lhs rhs
+
+
+let concat ?sep = function
+  | [] ->
+      string ""
+  | e :: es ->
+      let add e1 e2 =
+        match sep with
+        | None ->
+            add_eval e1 e2
+        | Some sep ->
+            add_eval e1 (add_eval sep e2)
+      in
+      CCList.fold_left add e es
+
+
+let simplify e =
+  let rec simplify_rec e acc_string acc_list =
+    match e with
+    | [] ->
+        acc_list
+    | Value (Literal (String s)) :: t ->
+        simplify_rec t (acc_string ^ s) acc_list
+    | h :: t ->
+        simplify_rec
+          t
+          ""
+          ( acc_list
+          @ (match acc_string with "" -> [] | _ -> [ string acc_string ])
+          @ [ h ] )
+  in
+  concat (simplify_rec e "" [])
+
+
+let all = function
+  | [] ->
+      bool true
+  | e :: es ->
+      CCList.fold_left
+        (fun e c ->
+          match c with Value (Literal (Bool true)) -> e | _ -> and_ e c)
+        e
+        es
+
+
+let convert_timestamp_localmktdate date =
+  funcall "timestamp_to_localmktdate" [ date ]
+
+
+let convert_timestamp_dateonly date = funcall "timestamp_to_dateonly" [ date ]
+
+let empty_record : record = String_map.empty
+
+let rec map_value_in_record (path : string list) f (record : record) =
+  match path with
+  | [] ->
+      record
+  | [ field ] ->
+      record |> String_map.update field f
+  | field :: path ->
+      record
+      |> String_map.update field (fun entry ->
+             let record =
+               match entry with
+               | Some (Rec_record record) ->
+                   record
+               | _ ->
+                   empty_record
+             in
+             Some (Rec_record (map_value_in_record path f record)))
+
+
+(** Given a record, return a list of paths to expressions that reference all the
+    fields in the record.
+
+    E.g. the record
+
+        Parties [
+          { PartyID = "123" }
+          { PartyID = "456" }
+        ]
+
+    Returns
+
+       [ (["Parties[0]"; "PartyID"], "123")
+       ; (["Parties[1]"; "PartyID"], "456")
+       ]
+*)
+let rec flatten_record ?qualify_records (r : record) : (string list * expr) list
+    =
+  r
+  |> String_map.to_list
+  |> CCList.flat_map (fun (field, (item : record_item)) ->
+         flatten_record_item ?qualify_records field item)
+
+
+and flatten_record_item ?(qualify_records = true) field (i : record_item) =
+  match i with
+  | Rec_value expr ->
+      [ ([ field ], expr) ]
+  | Rec_record record ->
+      flatten_record ~qualify_records record
+      |> CCList.map (fun (path, expr) ->
+             if qualify_records then (field :: path, expr) else (path, expr))
+  | Rec_repeating_group { num_in_group_field; elements } ->
+      elements
+      |> CCList.mapi (fun i record ->
+             flatten_record ~qualify_records record
+             |> CCList.map (fun (path, expr) ->
+                    ( field
+                      :: Printf.sprintf "%s[%i]" num_in_group_field i
+                      :: path
+                    , expr )))
+      |> CCList.concat
+
+
+module Template = struct
+  type t =
+    | Name of (string * string)
+    | Var of (Var.t * string)
+
+  let name s tag = Name (s, tag)
+
+  let var v tag = Var (Var.mk v, tag)
+
+  let to_json (t : t) : Yojson.Basic.t =
+    match t with
+    | Name (_, s) ->
+        `Assoc [ ("name", `String s) ]
+    | Var (_, s) ->
+        `Assoc [ ("var", `String s) ]
+
+
+  let pp fmt t =
+    let open CCFormat in
+    let pp_inner fmt = function
+      | Name (s, _) ->
+          pp_string fmt s
+      | Var (v, _) ->
+          Var.pp fmt v
+    in
+    fprintf fmt "%a" pp_inner t
+end
+
+type typed_term =
+  { name : string
+  ; type_ : string option
+  }
+
+type expecting =
+  { modifier : [ `Only | `Only_supported ] option
+  ; exprs : expr list
+  }
+
+type instruction =
+  | Break
+  | Print of expr
+  | Run of expr
+  | Sleep of expr
+  | Assert of expr
+  | Fail of expr option
+  | Return of expr option
+  | Goto of string
+  | Label of string
+  | Connect of
+      { connection : Connection_ref.t
+      ; timeout : expr option
+      ; block : bool
+      }
+  | Disconnect of Connection_ref.t
+  | Set of
+      { prop : string
+      ; value : expr
+      }
+  | Unset of value
+  | Call of
+      { variable : Var.t option
+      ; call : value
+      }
+  | Send of
+      { variable : Var.t option
+      ; template : Template.t
+      ; connection : Connection_ref.t
+      ; using : string option
+      ; withs : record option
+      }
+  | ExpectingOf of
+      { variable : Var.t
+      ; expecting : expecting
+      }
+  | Template of
+      { variable : Var.t option
+      ; template : Template.t
+      ; connection : Connection_ref.t
+      ; using : string option
+      }
+  | Cleanup of instruction list
+  | OnExpired of instruction list
+  | Repeat of
+      { ntimes : expr option
+      ; instructions : instruction list
+      }
+  | ForEach of
+      { dataset : expr
+      ; instructions : instruction list
+      }
+  | Receive of
+      { variable : Var.t option
+      ; connection : Connection_ref.t
+      ; timeout : expr option
+      ; where : expr
+      ; expecting : expecting option
+      }
+  | IfThenElse of
+      { cond : expr
+      ; then_ : instruction list
+      ; else_ : instruction list
+      }
+  | FunctionDef of
+      { name : string
+      ; args : typed_term list
+      ; body : instruction list
+      }
+  | Comment of string
+
+module Instructions_set = CCSet.Make (struct
+  type t = instruction list
+
+  let compare = Caml.compare
+end)
+
+module Value = struct
+  type t = value
+
+  let rec exists f v =
+    f v
+    ||
+    match v with
+    | Literal _
+    | Variable _
+    | MessageValue _
+    | ConnectionRef _
+    | TODOHex _
+    | Now
+    | Counter ->
+        false
+    | ObjectProperty { obj = e; index = _; prop = _ } ->
+        exists_expr f e
+    | Funcall { func = _; args = es } ->
+        CCList.exists (exists_expr f) es
+    | Record_item record_item ->
+        exists_record_item f record_item
+
+
+  and exists_expr f = function
+    | Value v ->
+        exists f v
+    | Not e ->
+        exists_expr f e
+    | Arrow { condition; assertion } ->
+        exists_expr f condition || exists_expr f assertion
+    | Or { lhs; rhs }
+    | And { lhs; rhs }
+    | Eq { lhs; rhs }
+    | Like { lhs; rhs }
+    | Cmp { lhs; rhs; op = _ }
+    | Add { lhs; rhs; op = _ }
+    | Mul { lhs; rhs; op = _ } ->
+        exists_expr f lhs || exists_expr f rhs
+    | In { el; set } ->
+        exists_expr f el || exists_expr f set
+
+
+  and exists_record_item f = function
+    | Rec_value e ->
+        exists_expr f e
+    | Rec_record record ->
+        exists_record f record
+    | Rec_repeating_group { num_in_group_field = _; elements } ->
+        CCList.exists (exists_record f) elements
+
+
+  and exists_record f =
+    String_map.exists (fun _ record_item -> exists_record_item f record_item)
+
+
+  let rec exists_instruction f = function
+    | Break | Goto _ | Label _ | Disconnect _ | Comment _ | Template _ ->
+        false
+    | Call { variable = _; call = v } | Unset v ->
+        exists f v
+    | ExpectingOf { variable = _; expecting = { exprs = es; modifier = _ } } ->
+        CCList.exists (exists_expr f) es
+    | Print e | Run e | Sleep e | Assert e | Set { prop = _; value = e } ->
+        exists_expr f e
+    | Fail e | Return e | Connect { connection = _; timeout = e; block = _ } ->
+        e |> CCOpt.exists (exists_expr f)
+    | Send
+        { variable = _
+        ; template = _
+        ; connection = _
+        ; using = _
+        ; withs = record
+        } ->
+        CCOpt.exists (exists_record f) record
+    | Cleanup is
+    | OnExpired is
+    | Repeat { ntimes = _; instructions = is }
+    | FunctionDef { name = _; args = _; body = is } ->
+        CCList.exists (exists_instruction f) is
+    | ForEach { dataset = e; instructions = is } ->
+        exists_expr f e || CCList.exists (exists_instruction f) is
+    | Receive { variable = _; connection = _; timeout; where; expecting } ->
+        CCOpt.exists (exists_expr f) timeout
+        || exists_expr f where
+        || CCOpt.exists
+             (fun (e : expecting) -> CCList.exists (exists_expr f) e.exprs)
+             expecting
+    | IfThenElse { cond; then_; else_ } ->
+        exists_expr f cond
+        || CCList.exists (exists_instruction f) then_
+        || CCList.exists (exists_instruction f) else_
+end
+
+let append ~to_ e = Set { prop = to_; value = add (var to_) e }
+
+(** Combine:
+
+      set x = $x + "1"
+      set x = $x + "2"
+
+    Into:
+
+      set x = $x + "1" + "2"
+*)
+let rec combine_appends ~var = function
+  | Set { prop = x1; value }
+    :: Set
+         { prop = x2
+         ; value = Add { lhs = Value (Variable (Var x3)); rhs; op = '+' }
+         }
+       :: is
+    when x1 = var && x2 = var && x3 = var ->
+      let i =
+        match value with
+        | Add { lhs = Value (Variable (Var x4)); rhs = value; op = '+' }
+          when x4 = var ->
+            append ~to_:var (add_eval value rhs)
+        | _ ->
+            Set { prop = var; value = add value rhs }
+      in
+      combine_appends ~var (i :: is)
+  | i :: is ->
+      i :: combine_appends ~var is
+  | [] ->
+      []
+
+
+let is_local_message_value = function
+  | Value (MessageValue { var = None; _ }) ->
+      true
+  | _ ->
+      false
+
+
+let rec eval_pp_value ~var (value : value) : instruction list =
+  let append e = append ~to_:var e in
+  match value with
+  | MessageValue ({ var = None; _ } as mv) ->
+      [ append (string (CCFormat.sprintf "%a" Message_value.pp mv)) ]
+  | Funcall _ ->
+      (* todo for printing *) []
+  | Literal _
+  | Variable _
+  | MessageValue _
+  | ConnectionRef _
+  | TODOHex _
+  | Now
+  | Counter
+  (* TODO *)
+  | ObjectProperty _
+  | Record_item _ ->
+      [ append (Value value) ]
+
+
+and eval_pp_expr ~var (e : expr) : instruction list =
+  let append e = append ~to_:var e in
+  let bin_expr lhs rhs op =
+    CCList.concat
+      [ eval_pp_expr ~var lhs
+      ; [ append (string (CCFormat.sprintf " %s " op)) ]
+      ; eval_pp_expr ~var rhs
+      ]
+  in
+  let instructions =
+    if exists is_local_message_value e
+    then
+      match e with
+      | Value v ->
+          eval_pp_value ~var v
+      | Not e ->
+          CCList.concat
+            [ [ append (string "(not ") ]
+            ; eval_pp_expr ~var e
+            ; [ append (string ")") ]
+            ]
+      | Arrow { condition; assertion } ->
+          bin_expr condition assertion "->"
+      | Cmp { lhs; op; rhs } ->
+          bin_expr lhs rhs op
+      | Add { lhs; op; rhs } | Mul { lhs; op; rhs } ->
+          bin_expr lhs rhs (CCString.of_char op)
+      | Or { lhs = And { lhs = cond; rhs = when_true }; rhs = when_false }
+        when not (exists is_local_message_value cond) ->
+          [ IfThenElse
+              { cond
+              ; then_ = eval_pp_expr ~var when_true
+              ; else_ = eval_pp_expr ~var when_false
+              }
+          ]
+      | Or { lhs; rhs } ->
+          bin_expr lhs rhs "||"
+      | And { lhs; rhs } ->
+          bin_expr lhs rhs "&&"
+      | Eq { lhs; rhs } ->
+          bin_expr lhs rhs "="
+      | Like { lhs; rhs } ->
+          bin_expr lhs rhs "like"
+      | In { el; set } ->
+          bin_expr el set "in"
+    else [ append e ]
+  in
+  combine_appends ~var instructions
+
+
+let print expr = Print expr
+
+let set prop value = Set { prop; value }
+
+let call ?variable func args = Call { variable; call = Funcall { func; args } }
+
+let for_each ~dataset instructions = ForEach { dataset; instructions }
+
+let return expr = Return (Some expr)
+
+let not e = Not e
+
+let ite cond then_ else_ = IfThenElse { cond; then_; else_ }
+
+let connect ?timeout ?(block = true) connection =
+  Connect { connection; timeout; block }
+
+
+let send ?variable ~template ~to_ ?using ?values () =
+  Send { variable; template; connection = to_; using; withs = values }
+
+
+let expecting ?modifier exprs = { modifier; exprs }
+
+let receive ?variable ~from ?timeout ~where ?expecting () =
+  Receive { variable; connection = from; timeout; where; expecting }
+
+
+let expectingOf ~variable ~expecting = ExpectingOf { variable; expecting }
+
+[@@@logic]

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -127,6 +127,7 @@ type literal =
   | Coll of expr list
   | MapColl of (expr*expr) list
   | LiteralNone
+  | LiteralSome of expr
   | Datetime of datetime
 
 and value =

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -117,6 +117,7 @@ type datetime =
   | UTCDateOnly of Datetime.fix_utcdateonly
   | LocalMktDate of Datetime.fix_localmktdate
   | MonthYear of Datetime.fix_monthyear
+  | Duration of Datetime.fix_duration
 
 type literal =
   | Bool of bool

--- a/itr_ast/itr_ast.iml
+++ b/itr_ast/itr_ast.iml
@@ -599,6 +599,7 @@ type instruction =
       ; block : bool
       }
   | Disconnect of Connection_ref.t
+  | Action of {name:string;fields:field list}
   | Set of
       { prop : string
       ; value : expr
@@ -726,6 +727,8 @@ module Value = struct
         exists_expr f e
     | Fail e | Return e | Connect { connection = _; timeout = e; block = _ } ->
         e |> CCOpt.exists (exists_expr f)
+    | Action {fields;_} ->
+        CCList.exists (exists_record_item f) (List.map (fun x -> x.value) fields)
     | Send
         { variable = _
         ; template = _

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -95,8 +95,9 @@ let rec literal_decoder () : literal decoder =
           let+ c = list (expr_decoder ()) in
           Coll c
       | "MapColl" ->
-          let+ c = list (expr_pair_decoder ()) in
-          MapColl c
+          let* d = field "default" (expr_decoder ()) in
+          let+ c = field "elements" (list (expr_pair_decoder ())) in
+          MapColl (d,c)
       | "None" ->
           succeed LiteralNone
       | "Some" ->

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -216,7 +216,9 @@ and record_item_decoder () : record_item decoder =
       | "Rec_repeating_group" ->
           let* num_in_group_field = field "num_in_group_field" string in
           let* elements = field "elements" (list (record_decoder ())) in
-          succeed (Rec_repeating_group { num_in_group_field; elements })
+          let* name = field "name" string in
+          let* message_template = field "message_template" (nullable string) in
+          succeed (Rec_repeating_group { num_in_group_field; elements;name;message_template })
       | s ->
           fail @@ "unrecognised record_item: " ^ s)
 

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -1,6 +1,7 @@
-[@@@require "decoders-yojson"]
-
 [@@@program]
+[@@@require "decoders-yojson"]
+[@@@import "itr_ast.iml"]
+[@@@import "../src-core-pp/datetime_json.iml"]
 
 open Itr_ast
 open Decoders_yojson.Basic.Decode

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -1,0 +1,367 @@
+[@@@require "decoders-yojson"]
+
+[@@@program]
+
+open Itr_ast
+open Decoders_yojson.Basic.Decode
+open Datetime_json
+
+let name_and_index_decoder : (string * int option) decoder =
+  let* name = field "name" string in
+  let* index = field "index" (nullable int) in
+  let index = match index with None -> None | Some i -> Some (Z.of_int i) in
+  succeed (name, index)
+
+
+let message_value_decoder : Message_value.t decoder =
+  let* var_name = field "var_name" (nullable string) in
+  let var = match var_name with None -> None | Some v -> Some (Var.mk v) in
+  let* field_path = field "field_path" (list name_and_index_decoder) in
+  let mv : Message_value.t = { var; field_path } in
+  succeed mv
+
+
+let connection_ref_decoder : Connection_ref.t decoder =
+  single_field (function
+      | "string" ->
+          let+ s = string in
+          Connection_ref.String s
+      | "var" ->
+          let+ s = string in
+          Connection_ref.Var (Var.mk s)
+      | s ->
+          fail @@ "unrecognised connection_ref: " ^ s)
+
+
+let template_decoder : Template.t decoder =
+  single_field (function
+      | "name" ->
+          let+ s = string in
+          Template.Name (s, s)
+      | "var" ->
+          let+ s = string in
+          Template.Var (Var.mk s, s)
+      | _ ->
+          fail "unrecognised template")
+
+
+let datetime_decoder : datetime decoder =
+  single_field (function
+      | "UTCTimestamp" ->
+          let+ u = utctimestamp_micro_decoder in
+          UTCTimestamp u
+      | "UTCTimeOnly" ->
+          let+ u = utctimeonly_micro_decoder in
+          UTCTimeOnly u
+      | "UTCDateOnly" ->
+          let+ u = utcdateonly_decoder in
+          UTCDateOnly u
+      | "LocalMktDate" ->
+          let+ u = localmktdate_decoder in
+          LocalMktDate u
+      | "MonthYear" ->
+          let+ u = monthyear_decoder in
+          MonthYear u
+      | s ->
+          fail @@ "unrecognised datetime: " ^ s)
+
+
+let rec literal_decoder () : literal decoder =
+  single_field (function
+      | "Bool" ->
+          let+ b = bool in
+          Bool b
+      | "Int" ->
+          let+ i = string in
+          Int (Z.of_string i)
+      | "String" ->
+          let+ s = string in
+          ( match String.sub s 1 (String.length s - 2) with
+          | None ->
+              String ""
+          | Some s ->
+              String s )
+      | "Unquoted_string" ->
+          let+ s = string in
+          String s
+      | "Float" ->
+          let+ q = float in
+          Float (Q.of_float q)
+      | "Coll" ->
+          let+ c = list (expr_decoder ()) in
+          Coll c
+      | "None" ->
+          succeed LiteralNone
+      | "Datetime" ->
+          let+ d = datetime_decoder in
+          Datetime d
+      | s ->
+          fail @@ "unrecognised literal: " ^ s)
+
+
+and value_decoder () : Itr_ast.value decoder =
+  single_field (function
+      | "Literal" ->
+          let+ l = literal_decoder () in
+          Literal l
+      | "Variable" ->
+          let+ v = string in
+          Variable (Var.mk v)
+      | "Message_value" ->
+          let+ mv = message_value_decoder in
+          MessageValue mv
+      | "Connection_ref" ->
+          let+ c = connection_ref_decoder in
+          ConnectionRef c
+      | "TODOHex" ->
+          let+ h = string in
+          TODOHex h
+      | "Now" ->
+          succeed Now
+      | "Counter" ->
+          succeed Counter
+      | "ObjectProperty" ->
+          let* obj = field "obj" (expr_decoder ()) in
+          let* index = field "index" (nullable int) in
+          let index = CCOpt.map (fun x -> Z.of_int x) index in
+          let* prop = field "prop" string in
+          succeed (ObjectProperty { obj; index; prop })
+      | "Funcall" ->
+          let* func = field "name" string in
+          let* args = field "args" (list (expr_decoder ())) in
+          succeed (Funcall { func; args })
+      | "Record_item" ->
+          let+ ri = record_item_decoder () in
+          Record_item ri
+      | s ->
+          fail @@ "unrecognised value:" ^ s)
+
+
+and expr_decoder () : expr decoder =
+  single_field (function
+      | "Value" ->
+          let+ v = value_decoder () in
+          Value v
+      | "Not" ->
+          let+ n = expr_decoder () in
+          Not n
+      | "Arrow" ->
+          let* condition = field "condition" (expr_decoder ()) in
+          let* assertion = field "assertion" (expr_decoder ()) in
+          succeed (Arrow { assertion; condition })
+      | "Or" ->
+          let* lhs = field "lhs" (expr_decoder ()) in
+          let* rhs = field "rhs" (expr_decoder ()) in
+          succeed (Or { lhs; rhs })
+      | "And" ->
+          let* lhs = field "lhs" (expr_decoder ()) in
+          let* rhs = field "rhs" (expr_decoder ()) in
+          succeed (And { lhs; rhs })
+      | "Eq" ->
+          let* lhs = field "lhs" (expr_decoder ()) in
+          let* rhs = field "rhs" (expr_decoder ()) in
+          succeed (Eq { lhs; rhs })
+      | "Like" ->
+          field
+            "Like"
+            (let* lhs = field "lhs" (expr_decoder ()) in
+             let* rhs = field "rhs" (expr_decoder ()) in
+             succeed (Like { lhs; rhs }))
+      | "Cmp" ->
+          let* lhs = field "lhs" (expr_decoder ()) in
+          let* op = field "op" string in
+          let* rhs = field "rhs" (expr_decoder ()) in
+          succeed (Cmp { lhs; op; rhs })
+      | "Add" ->
+          let* lhs = field "lhs" (expr_decoder ()) in
+          let* op = field "op" string in
+          let op =
+            match String.sub op 0 1 with None -> '+' | Some c -> c.[0i]
+          in
+          let* rhs = field "rhs" (expr_decoder ()) in
+          succeed (Add { lhs; op; rhs })
+      | "Mul" ->
+          let* lhs = field "lhs" (expr_decoder ()) in
+          let* op = field "op" string in
+          let op =
+            match String.sub op 0 1 with None -> '*' | Some c -> c.[0i]
+          in
+          let* rhs = field "rhs" (expr_decoder ()) in
+          succeed (Mul { lhs; op; rhs })
+      | "In" ->
+          let* el = field "el" (expr_decoder ()) in
+          let* set = field "set" (expr_decoder ()) in
+          succeed (In { el; set })
+      | s ->
+          fail @@ "unrecognised expr: " ^ s)
+
+
+and record_item_decoder () : record_item decoder =
+  single_field (function
+      | "Rec_value" ->
+          let+ v = expr_decoder () in
+          Rec_value v
+      | "Rec_record" ->
+          let+ is = record_decoder () in
+          Rec_record is
+      | "Rec_repeating_group" ->
+          let* num_in_group_field = field "num_in_group_field" string in
+          let* elements = field "elements" (list (record_decoder ())) in
+          succeed (Rec_repeating_group { num_in_group_field; elements })
+      | s ->
+          fail @@ "unrecognised record_item: " ^ s)
+
+
+and record_decoder () : record decoder =
+  field
+    "Record"
+    (let+ sm =
+       list
+         (let* name = field "name" string in
+          let* record_item = field "record_item" (record_item_decoder ()) in
+          succeed (name, record_item))
+     in
+     String_map.of_list sm)
+
+
+let expecting_decoder : expecting decoder =
+  let* modifier = field "modifier" (nullable string) in
+  let modifier =
+    CCOpt.map
+      (function "only supported" -> `Only_supported | _ -> `Only)
+      modifier
+  in
+  let* exprs = field "exprs" (list (expr_decoder ())) in
+  succeed { modifier; exprs }
+
+
+let tt_decoder : typed_term decoder =
+  field
+    "typed_term"
+    (let* name = field "name" string in
+     let* type_ = field "type" (nullable string) in
+     succeed { name; type_ })
+
+
+let rec instruction_decoder () : instruction decoder =
+  single_field (function
+      | "Break" ->
+          let+ _ = nullable string in
+          Break
+      | "Print" ->
+          let+ e = expr_decoder () in
+          Print e
+      | "Run" ->
+          let+ e = expr_decoder () in
+          Run e
+      | "Sleep" ->
+          let+ e = expr_decoder () in
+          Sleep e
+      | "Assert" ->
+          let+ e = expr_decoder () in
+          Assert e
+      | "Fail" ->
+          let+ e = nullable (expr_decoder ()) in
+          Fail e
+      | "Return" ->
+          let+ e = nullable (expr_decoder ()) in
+          Return e
+      | "Goto" ->
+          let+ g = string in
+          Goto g
+      | "Label" ->
+          let+ l = string in
+          Label l
+      | "Disonnect" ->
+          let+ s = connection_ref_decoder in
+          Disconnect s
+      | "Unset" ->
+          let+ v = value_decoder () in
+          Unset v
+      | "Cleanup" ->
+          let+ i = list (instruction_decoder ()) in
+          Cleanup i
+      | "OnExpired" ->
+          let+ i = list (instruction_decoder ()) in
+          OnExpired i
+      | "ForEach" ->
+          let* dataset = field "dataset" (expr_decoder ()) in
+          let* instructions =
+            field "instructions" (list (instruction_decoder ()))
+          in
+          succeed (ForEach { dataset; instructions })
+      | "Repeat" ->
+          let* ntimes = field "ntimes" (nullable (expr_decoder ())) in
+          let* instructions =
+            field "instructions" (list (instruction_decoder ()))
+          in
+          succeed (Repeat { ntimes; instructions })
+      | "Connect" ->
+          let* connection = field "connection" connection_ref_decoder in
+          let* timeout = field "timeout" (nullable (expr_decoder ())) in
+          let* block = field "block" bool in
+          succeed (Connect { connection; timeout; block })
+      | "Set" ->
+          let* prop = field "prop" string in
+          let* value = field "value" (expr_decoder ()) in
+          succeed (Set { prop; value })
+      | "Call" ->
+          let* variable = field "variable" (nullable string) in
+          let variable = CCOpt.map (fun v -> Var.mk v) variable in
+          let* call = field "call" (value_decoder ()) in
+          succeed (Call { variable; call })
+      | "Send" ->
+          let* variable = field "variable" (nullable string) in
+          let variable = CCOpt.map (fun v -> Var.mk v) variable in
+          let* template = field "template" template_decoder in
+          let* connection = field "connection" connection_ref_decoder in
+          let* using = field "using" (nullable string) in
+          let* withs = field "withs" (nullable (record_decoder ())) in
+          succeed (Send { variable; template; connection; using; withs })
+      | "ExpectingOf" ->
+          let* variable = field "variable" string in
+          let variable = Var.mk variable in
+          let* expecting = field "expecting" expecting_decoder in
+          succeed (ExpectingOf { variable; expecting })
+      | "Template" ->
+          let* variable = field "variable" (nullable string) in
+          let variable = CCOpt.map (fun v -> Var.mk v) variable in
+          let* template = field "template" template_decoder in
+          let* connection = field "connection" connection_ref_decoder in
+          let* using = field "using" (nullable string) in
+          succeed (Template { variable; template; connection; using })
+      | "Receive" ->
+          let* variable = field "variable" (nullable string) in
+          let variable = CCOpt.map (fun v -> Var.mk v) variable in
+          let* connection = field "connection" connection_ref_decoder in
+          let* timeout = field "timeout" (nullable (expr_decoder ())) in
+          let* where = field "where" (expr_decoder ()) in
+          let* expecting = field "expecting" (nullable expecting_decoder) in
+          succeed (Receive { variable; connection; timeout; where; expecting })
+      | "IfThenElse" ->
+          let* cond = field "cond" (expr_decoder ()) in
+          let* then_ = field "then" (list (instruction_decoder ())) in
+          let* else_ = field "else" (list (instruction_decoder ())) in
+          succeed (IfThenElse { cond; then_; else_ })
+      | "FunctionDef" ->
+          let* name = field "name" string in
+          let* args = field "args" (list tt_decoder) in
+          let* body = field "body" (list (instruction_decoder ())) in
+          succeed (FunctionDef { name; args; body })
+      | "Comment" ->
+          let+ comment = string in
+          Comment comment
+      | _ ->
+          fail "unrecognised instruction")
+
+
+let instructions_decoder :
+    (instruction list * Model_messages.model_msg_opt_def list) decoder =
+  let* instructions = field "instructions" (list (instruction_decoder ())) in
+  let* msgs =
+    field "msgs" (list Json_to_message.model_message_decoder_opt_def)
+  in
+  succeed (instructions, msgs)
+
+
+[@@@logic]

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -275,6 +275,10 @@ let rec instruction_decoder () : instruction decoder =
           let* name = field "name" string in
           let+ fields = field "fields" (list (field_decoder ())) in
           Action {name;fields}
+      | "Message" ->
+          let* name = field "name" string in
+          let+ fields = field "fields" (list (field_decoder ())) in
+          Message {name;fields}
       | "Assert" ->
           let+ e = expr_decoder () in
           Assert e

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -328,7 +328,7 @@ let rec instruction_decoder () : instruction decoder =
           succeed (Connect { connection; timeout; block })
       | "Set" ->
           let* prop = field "prop" string in
-          let* value = field "value" (expr_decoder ()) in
+          let* value = field "value" (record_item_decoder ()) in
           succeed (Set { prop; value })
       | "Call" ->
           let* variable = field "variable" (nullable string) in

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -362,7 +362,8 @@ let rec instruction_decoder () : instruction decoder =
           let* timeout = field "timeout" (nullable (expr_decoder ())) in
           let* where = field "where" (expr_decoder ()) in
           let* expecting = field "expecting" (nullable expecting_decoder) in
-          succeed (Receive { variable; connection; timeout; where; expecting })
+          let+ example = field "example" (record_decoder ()) in
+          (Receive { variable; connection; timeout; where; expecting; example })
       | "IfThenElse" ->
           let* cond = field "cond" (expr_decoder ()) in
           let* then_ = field "then" (list (instruction_decoder ())) in

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -63,6 +63,9 @@ let datetime_decoder : datetime decoder =
       | "MonthYear" ->
           let+ u = monthyear_decoder in
           MonthYear u
+      | "Duration" ->
+          let+ u = duration_decoder in
+          Duration u
       | s ->
           fail @@ "unrecognised datetime: " ^ s)
 

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -96,6 +96,9 @@ let rec literal_decoder () : literal decoder =
           MapColl c
       | "None" ->
           succeed LiteralNone
+      | "Some" ->
+          let+ e = expr_decoder () in
+          LiteralSome e
       | "Datetime" ->
           let+ d = datetime_decoder in
           Datetime d

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -222,17 +222,16 @@ and record_item_decoder () : record_item decoder =
       | s ->
           fail @@ "unrecognised record_item: " ^ s)
 
-
 and record_decoder () : record decoder =
   field
     "Record"
-    (let+ sm =
-       list
+    (let* elements = field "elements"
+       (list
          (let* name = field "name" string in
           let* record_item = field "record_item" (record_item_decoder ()) in
-          succeed (name, record_item))
-     in
-     String_map.of_list sm)
+          succeed (name, record_item))) in
+    let* name = field "name" string in
+    succeed {name;elements = String_map.of_list elements})
 
 
 let expecting_decoder : expecting decoder =

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -91,6 +91,9 @@ let rec literal_decoder () : literal decoder =
       | "Coll" ->
           let+ c = list (expr_decoder ()) in
           Coll c
+      | "MapColl" ->
+          let+ c = list (expr_pair_decoder ()) in
+          MapColl c
       | "None" ->
           succeed LiteralNone
       | "Datetime" ->
@@ -98,6 +101,11 @@ let rec literal_decoder () : literal decoder =
           Datetime d
       | s ->
           fail @@ "unrecognised literal: " ^ s)
+
+and expr_pair_decoder () : (Itr_ast.expr * Itr_ast.expr) decoder =
+    let* key = field "key" (expr_decoder ()) in
+    let* value = field "value" (expr_decoder ()) in
+    succeed (key,value)
 
 
 and value_decoder () : Itr_ast.value decoder =

--- a/itr_ast/itr_ast_decoder.iml
+++ b/itr_ast/itr_ast_decoder.iml
@@ -252,6 +252,10 @@ let tt_decoder : typed_term decoder =
      let* type_ = field "type" (nullable string) in
      succeed { name; type_ })
 
+let field_decoder (): field decoder =
+    let* name = field "name" string in
+    let+ value = field "value" (record_item_decoder ()) in
+    {name;value}
 
 let rec instruction_decoder () : instruction decoder =
   single_field (function
@@ -267,6 +271,10 @@ let rec instruction_decoder () : instruction decoder =
       | "Sleep" ->
           let+ e = expr_decoder () in
           Sleep e
+      | "Action" ->
+          let* name = field "name" string in
+          let+ fields = field "fields" (list (field_decoder ())) in
+          Action {name;fields}
       | "Assert" ->
           let+ e = expr_decoder () in
           Assert e

--- a/itr_ast/itr_ast_ipl_decoder.iml
+++ b/itr_ast/itr_ast_ipl_decoder.iml
@@ -8,139 +8,12 @@ open Parse_base_types;;
 open Parse_datetime;;
 
 
-module My_result = struct
-  type ('good, 'bad) t = ('good, 'bad) result = | Ok of 'good | Error of 'bad
-
-  let return x = Ok x
-  let map f e = match e with
-    | Ok x -> Ok (f x)
-    | Error s -> Error s
-  let map_err f e = match e with
-    | Ok _ as res -> res
-    | Error y -> Error (f y)
-  let flat_map f e = match e with
-    | Ok x -> f x
-    | Error s -> Error s
-
-  module Infix = struct
-    let (>|=) e f = map f e
-    let (>>=) e f = flat_map f e
-  end
-end
-
-
-module My_opt = struct
-  let return x = Some x
-  let map f = function None -> None | Some x -> Some (f x)
-  let flat_map f o = match o with
-    | None -> None
-    | Some x -> f x
-end
-
-module My_list = struct
-  let take n l =
-    let rec direct i n l = match l with
-      | [] -> []
-      | _ when i=0 -> safe n [] l
-      | x::l' ->
-        if n > 0
-        then x :: direct (i-1) (n-1) l'
-        else []
-    and safe n acc l = match l with
-      | [] -> List.rev acc
-      | _ when n=0 -> List.rev acc
-      | x::l' -> safe (n-1) (x::acc) l'
-    in
-    direct 500 n l
-
-  let map f l =
-    let rec direct f i l = match l with
-      | [] -> []
-      | [x] -> [f x]
-      | [x1;x2] -> let y1 = f x1 in [y1; f x2]
-      | [x1;x2;x3] -> let y1 = f x1 in let y2 = f x2 in [y1; y2; f x3]
-      | _ when i=0 -> CCList.rev (CCList.rev_map f l)
-      | x1::x2::x3::x4::l' ->
-        let y1 = f x1 in
-        let y2 = f x2 in
-        let y3 = f x3 in
-        let y4 = f x4 in
-        y1 :: y2 :: y3 :: y4 :: direct f (i-1) l'
-    in
-    direct f 500 l
-
-  let all_some l =
-    try Some (map (function Some x -> x | None -> raise Exit) l)
-    with Exit -> None
-
-  let mapi f l =
-    let r = ref 0 in
-    map
-      (fun x ->
-         let y = f !r x in
-         r := !r+1; y
-      ) l
-
-  let find_map f l =
-    let rec aux f = function
-      | [] -> None
-      | x::l' ->
-        match f x with
-          | Some _ as res -> res
-          | None -> aux f l'
-    in aux f l
-
-  let filter_map f l =
-    let rec recurse acc l = match l with
-      | [] -> List.rev acc
-      | x::l' ->
-        let acc' = match f x with | None -> acc | Some y -> y::acc in
-        recurse acc' l'
-    in recurse [] l
-
-  let fold_left = CCList.fold_left
-
-  let direct_depth_append_ = 10_000
-
-  let append l1 l2 =
-    let rec direct i l1 l2 = match l1 with
-      | [] -> l2
-      | _ when i=0 -> safe l1 l2
-      | x::l1' -> x :: direct (i-1) l1' l2
-    and safe l1 l2 =
-      CCList.rev_append (List.rev l1) l2
-    in
-    match l1 with
-    | [] -> l2
-    | [x] -> x::l2
-    | [x;y] -> x::y::l2
-    | _ -> direct direct_depth_append_ l1 l2
-
-  let (@) = append
-
-  let flat_map f l =
-    let rec aux f l kont = match l with
-      | [] -> kont []
-      | x::l' ->
-        let y = f x in
-        let kont' tail = match y with
-          | [] -> kont tail
-          | [x] -> kont (x :: tail)
-          | [x;y] -> kont (x::y::tail)
-          | l -> kont (append l tail)
-        in
-        aux f l' kont'
-    in
-    aux f l (fun l->l)
-end
-
-
 type 'value exposed_error =
   | Decoder_error of string * 'value option
   | Decoder_errors of 'value exposed_error list
   | Decoder_tag of string * 'value exposed_error
 
-type ('good, 'bad) result = ('good, 'bad) My_result.t = Ok of 'good | Error of 'bad
+type ('good, 'bad) result = ('good, 'bad) CCResult.t = Ok of 'good | Error of 'bad
 
 type ('value, 'a) exposed_runner_decoder = { run : 'value -> ('a, 'value exposed_error) result }
 
@@ -155,7 +28,7 @@ module RunnerDecoder  = struct
     | Decoder_error (msg, Some t) -> Format.fprintf fmt "@[%s, but got@ @[%a@]@]" msg pp t
     | Decoder_error (msg, None) -> Format.fprintf fmt "@[%s@]" msg
     | Decoder_errors errors ->
-      let errors_trunc = My_list.take 5 errors in
+      let errors_trunc = CCList.take 5i errors in
       let not_shown = List.length errors - 5 in
       Format.fprintf fmt "@[%a@ %s@]"
         (Format.pp_print_list ~pp_sep:Format.pp_print_space pp_error) errors_trunc
@@ -166,39 +39,48 @@ module RunnerDecoder  = struct
         pp_error error
 
 
-      let of_file _file =
+  let of_file _file =
 
-         Error "not supported"
+    Error "not supported"
 
-      let get_string = function
-        | Rec_value (Value (Literal (String value))) -> Some value
-        | _ -> None
+  let get_string = function
+    | Rec_value (Value (Literal (String value))) -> Some value
+    | _ -> None
 
-      let get_int = function
-        | Rec_value (Value (Literal (Int value))) -> Some value
-        | _ -> None
+  let get_int = function
+    | Rec_value (Value (Literal (Int value))) -> Some value
+    | _ -> None
 
-      let get_float = function
-        | Rec_value (Value (Literal (Float value))) -> Some value
-        | Rec_value (Value (Literal (Int value))) -> Some (Q.of_bigint value)
-        | _ -> None
+  let get_float = function
+    | Rec_value (Value (Literal (Float value))) -> Some value
+    | Rec_value (Value (Literal (Int value))) -> Some (Q.of_bigint value)
+    | _ -> None
 
-      let get_bool = function
-        |  Rec_value (Value (Literal (Bool value))) -> Some value
-        | _ -> None
+  let get_bool = function
+    |  Rec_value (Value (Literal (Bool value))) -> Some value
+    | _ -> None
 
-      let get_null = function
-        | _ -> None
+  let get_null = function
+    | _ -> None
 
-      let get_list : value -> value list option = function
-       (* | `List l -> Some l *)
-        | _ -> None
-    (* use this as record assoc?*)
-      let get_key_value_pairs : value -> (value * value) list option = function
-      (*   | `Assoc assoc -> Some (List.map (fun (key, value) -> (`String key, value)) assoc) *)
-        | _ -> None
+  let get_list : value -> value list option = function
+    | Rec_value (Value (Literal (Coll values))) -> Some values
+    | _ -> None
 
-      let to_list values = Rec_value (Value (Literal LiteralNone))
+  let get_set : value -> value Set.t option = function
+    | Rec_value (Value (Literal (Coll values))) -> Some (Set.of_list values)
+    | _ -> None
+
+  let get_map : value -> (value,value) Map.t option = function
+    | Rec_value (Value (Literal (MapColl (default,values)))) -> Some (Map.of_list ~default values)
+    | _ -> None
+
+  let get_key_value_pairs : value -> (value * value) list option = function
+    | Rec_record {elements;_} -> Some (List.map (fun (key,value) ->
+        (Rec_value (Value (Literal (String key))),value)) (String_map.to_list elements))
+    | _ -> None
+
+  let to_list values = Rec_value (Value (Literal (Coll values)))
 
   let string_of_error e : string =
     Format.asprintf "@[<2>%a@?@]" pp_error e
@@ -236,9 +118,9 @@ module RunnerDecoder  = struct
     aux (Ok []) results
 
   (* let of_string : string -> (value, error) result =
-    fun string ->
-    of_string string
-    |> My_result.map_err (fun msg ->
+     fun string ->
+     of_string string
+     |> My_result.map_err (fun msg ->
         (Decoder_tag ("Json parse error", Decoder_error (msg, None)))
       ) *)
 
@@ -261,7 +143,7 @@ module RunnerDecoder  = struct
     { run = fun input -> Ok input }
 
   let map f runner_decoder =
-    { run = fun input -> My_result.Infix.(runner_decoder.run input >|= f) }
+    { run = fun input -> CCResult.Infix.(runner_decoder.run input >|= f) }
 
   let apply : ('a -> 'b) runner_decoder -> 'a runner_decoder -> 'b runner_decoder =
     fun f runner_decoder ->
@@ -276,7 +158,7 @@ module RunnerDecoder  = struct
 
   let and_then (f : 'a -> 'b runner_decoder) (runner_decoder : 'a runner_decoder) : 'b runner_decoder =
     { run = fun input ->
-          My_result.Infix.(
+          CCResult.Infix.(
             runner_decoder.run input >>= fun result ->
             (f result).run input)
     }
@@ -309,8 +191,8 @@ module RunnerDecoder  = struct
           | Some () -> Ok None
           | None ->
             runner_decoder.run input
-            |> My_result.map My_opt.return
-            |> My_result.map_err (tag_error "Expected null or")
+            |> CCResult.map CCOpt.return
+            |> CCResult.map_err (tag_error "Expected null or")
     }
 
   let one_of : (string * 'a runner_decoder) list -> 'a runner_decoder =
@@ -359,13 +241,13 @@ module RunnerDecoder  = struct
           | None -> (fail "Expected a list").run t
           | Some values ->
             values
-            |> My_list.mapi (fun i x ->
+            |> CCList.mapi (fun i x ->
                 runner_decoder.run x
-                |> My_result.map_err
-                  (tag_error (Printf.sprintf "element %i" (Z.to_int i)))
+                |> CCResult.map_err
+                  (tag_error (Printf.sprintf "element %i" i))
               )
             |> combine_errors
-            |> My_result.map_err
+            |> CCResult.map_err
               (tag_errors "while decoding a list")
     }
 
@@ -374,13 +256,13 @@ module RunnerDecoder  = struct
     let rec go i = function
       | [] -> Ok []
       | v :: vs ->
-        My_result.Infix.(
+        CCResult.Infix.(
           runner_decoder.run v
-          |> My_result.map_err
+          |> CCResult.map_err
             (tag_error (Printf.sprintf "element %i" (Z.to_int i))) >>= function
           | Some x ->
             go (i + 1) vs >>= fun xs ->
-            My_result.return (x :: xs)
+            CCResult.return (x :: xs)
           | None -> go (i + 1) vs
         )
     in
@@ -390,7 +272,7 @@ module RunnerDecoder  = struct
           | None -> (fail "Expected a list").run t
           | Some values ->
             go 0 values
-            |> My_result.map_err (tag_error "while decoding a list")
+            |> CCResult.map_err (tag_error "while decoding a list")
     }
 
   let list_fold_left : ('a -> 'a runner_decoder) -> 'a -> 'a runner_decoder =
@@ -402,12 +284,12 @@ module RunnerDecoder  = struct
           | None -> (fail "Expected a list").run t
           | Some values ->
             values
-            |> My_result.Infix.(My_list.fold_left (fun (acc,i) el ->
+            |> CCResult.Infix.(CCList.fold_left (fun (acc,i) el ->
                 (acc >>= fun acc ->
                  (acc |> runner_decoder_func).run el
-                 |> My_result.map_err (tag_error (Printf.sprintf "element %i" i))),Z.to_int ((Z.of_int i)+1))
+                 |> CCResult.map_err (tag_error (Printf.sprintf "element %i" i))),Z.to_int ((Z.of_int i)+1))
               )  (Ok init,0i) |> fst
-            |> My_result.map_err (tag_error "while decoding a list")
+            |> CCResult.map_err (tag_error "while decoding a list")
     }
 
   let field : string -> 'a runner_decoder -> 'a runner_decoder =
@@ -416,7 +298,7 @@ module RunnerDecoder  = struct
         fun t ->
           let value =
             get_key_value_pairs t
-            |> My_opt.flat_map (My_list.find_map (fun (k, v) ->
+            |> CCOpt.flat_map (CCList.find_map (fun (k, v) ->
                 match get_string k with
                 | Some s when s = key -> Some v
                 | _ -> None
@@ -425,7 +307,7 @@ module RunnerDecoder  = struct
           match value with
           | Some value ->
             value_runner_decoder.run value
-            |> My_result.map_err (tag_error (Printf.sprintf "in field %S" key))
+            |> CCResult.map_err (tag_error (Printf.sprintf "in field %S" key))
           | None -> (fail (Printf.sprintf "Expected an object with an attribute %S" key)).run t
     }
 
@@ -435,7 +317,7 @@ module RunnerDecoder  = struct
         fun t ->
           let value =
             get_key_value_pairs t
-            |> My_opt.flat_map (My_list.find_map (fun (k, v) ->
+            |> CCOpt.flat_map (CCList.find_map (fun (k, v) ->
                 match get_string k with
                 | Some s when s = key -> Some v
                 | _ -> None
@@ -444,8 +326,8 @@ module RunnerDecoder  = struct
           match value with
           | Some value ->
             value_runner_decoder.run value
-            |> My_result.map (fun v -> Some v)
-            |> My_result.map_err (tag_error (Printf.sprintf "in field %S" key))
+            |> CCResult.map (fun v -> Some v)
+            |> CCResult.map_err (tag_error (Printf.sprintf "in field %S" key))
           | None -> Ok None
     }
 
@@ -458,7 +340,7 @@ module RunnerDecoder  = struct
             begin match get_string key with
               | Some key ->
                 (value_runner_decoder key).run value
-                |> My_result.map_err (tag_error (Printf.sprintf "in field %S" key))
+                |> CCResult.map_err (tag_error (Printf.sprintf "in field %S" key))
               | None -> (fail "Expected an object with a string key").run t
             end
           | _ -> (fail "Expected an object with a single attribute").run t
@@ -483,16 +365,16 @@ module RunnerDecoder  = struct
     { run =
         fun value ->
           match get_list value with
-        | Some (x :: rest) ->
-          My_result.Infix.(
-            head.run x
-            |> My_result.map_err (tag_error "while consuming a list element")
-            >>= fun x ->
-            (tail x).run (to_list rest)
-            |> My_result.map_err (tag_error "after consuming a list element")
-          )
-        | Some [] -> (fail "Expected a non-empty list").run value
-        | None -> (fail "Expected a list").run value
+          | Some (x :: rest) ->
+            CCResult.Infix.(
+              head.run x
+              |> CCResult.map_err (tag_error "while consuming a list element")
+              >>= fun x ->
+              (tail x).run (to_list rest)
+              |> CCResult.map_err (tag_error "after consuming a list element")
+            )
+          | Some [] -> (fail "Expected a non-empty list").run value
+          | None -> (fail "Expected a list").run value
     }
 
   let rec at : string list -> 'a runner_decoder -> 'a runner_decoder = fun path runner_decoder ->
@@ -510,7 +392,7 @@ module RunnerDecoder  = struct
             assoc
             |> List.map (fun (key, _) -> key_runner_decoder.run key)
             |> combine_errors
-            |> My_result.map_err
+            |> CCResult.map_err
               (tag_errors "Failed while decoding the keys of an object")
           | None -> (fail "Expected an object").run value
     }
@@ -524,14 +406,14 @@ module RunnerDecoder  = struct
           match get_key_value_pairs value with
           | Some assoc ->
             assoc
-            |> List.map
-              My_result.Infix.(fun (key_val, value_val) ->
+            |> CCList.map
+              CCResult.Infix.(fun (key_val, value_val) ->
                   key_runner_decoder.run key_val >>= fun key ->
                   value_runner_decoder.run value_val >|= fun value ->
                   (key, value)
                 )
             |> combine_errors
-            |> My_result.map_err
+            |> CCResult.map_err
               (tag_errors "Failed while decoding key-value pairs")
           | None -> (fail "Expected an object").run value
     }
@@ -545,13 +427,13 @@ module RunnerDecoder  = struct
           match get_key_value_pairs value with
           | Some assoc ->
             assoc
-            |> List.map
-              My_result.Infix.(fun (key_val, value_val) ->
+            |> CCList.map
+              CCResult.Infix.(fun (key_val, value_val) ->
                   key_runner_decoder.run key_val >>= fun key ->
                   (value_runner_decoder key).run value_val
                 )
             |> combine_errors
-            |> My_result.map_err
+            |> CCResult.map_err
               (tag_errors "Failed while decoding key-value pairs")
           | None -> (fail "Expected an object").run value
     }

--- a/itr_ast/itr_ast_ipl_decoder.iml
+++ b/itr_ast/itr_ast_ipl_decoder.iml
@@ -7,6 +7,9 @@ open Parse_base_types;;
 [@@@import "../src-core-pp/parse_datetime.iml"]
 open Parse_datetime;;
 
+(* This decoder stucture is based on the decoders and decoders-yojson project *)
+(* written by Matt Bray here https://mattjbray.github.io/ocaml-decoders/      *)
+
 
 type 'value exposed_error =
   | Decoder_error of string * 'value option

--- a/itr_ast/itr_ast_ipl_decoder.iml
+++ b/itr_ast/itr_ast_ipl_decoder.iml
@@ -64,15 +64,15 @@ module RunnerDecoder  = struct
     | _ -> None
 
   let get_list : value -> value list option = function
-    | Rec_value (Value (Literal (Coll values))) -> Some values
+    | Rec_value (Value (Literal (Coll values))) -> Some (List.map (fun x -> Rec_value x) values)
     | _ -> None
 
   let get_set : value -> value Set.t option = function
-    | Rec_value (Value (Literal (Coll values))) -> Some (Set.of_list values)
+    | Rec_value (Value (Literal (Coll values))) -> Some (Set.of_list ((List.map (fun x -> Rec_value x) values)))
     | _ -> None
 
   let get_map : value -> (value,value) Map.t option = function
-    | Rec_value (Value (Literal (MapColl (default,values)))) -> Some (Map.of_list ~default values)
+    | Rec_value (Value (Literal (MapColl (default,values)))) -> Some (Map.of_list ~default:(Rec_value default) (List.map (fun (x,y) -> (Rec_value x,Rec_value y)) values))
     | _ -> None
 
   let get_key_value_pairs : value -> (value * value) list option = function
@@ -80,7 +80,7 @@ module RunnerDecoder  = struct
         (Rec_value (Value (Literal (String key))),value)) (String_map.to_list elements))
     | _ -> None
 
-  let to_list values = Rec_value (Value (Literal (Coll values)))
+  let to_list values = Rec_value (Value (Literal (Coll (List.map (fun x -> Value (Record_item x)) values))))
 
   let string_of_error e : string =
     Format.asprintf "@[<2>%a@?@]" pp_error e

--- a/itr_ast/itr_ast_ipl_decoder.iml
+++ b/itr_ast/itr_ast_ipl_decoder.iml
@@ -1,0 +1,611 @@
+(* Imandra Inc. copyright 2021 *)
+[@@@program]
+[@@@import "itr_ast.iml"]
+open Itr_ast;;
+[@@@import "../src-core-pp/parse_base_types.iml"]
+open Parse_base_types;;
+[@@@import "../src-core-pp/parse_datetime.iml"]
+open Parse_datetime;;
+
+
+module My_result = struct
+  type ('good, 'bad) t = ('good, 'bad) result = | Ok of 'good | Error of 'bad
+
+  let return x = Ok x
+  let map f e = match e with
+    | Ok x -> Ok (f x)
+    | Error s -> Error s
+  let map_err f e = match e with
+    | Ok _ as res -> res
+    | Error y -> Error (f y)
+  let flat_map f e = match e with
+    | Ok x -> f x
+    | Error s -> Error s
+
+  module Infix = struct
+    let (>|=) e f = map f e
+    let (>>=) e f = flat_map f e
+  end
+end
+
+
+module My_opt = struct
+  let return x = Some x
+  let map f = function None -> None | Some x -> Some (f x)
+  let flat_map f o = match o with
+    | None -> None
+    | Some x -> f x
+end
+
+module My_list = struct
+  let take n l =
+    let rec direct i n l = match l with
+      | [] -> []
+      | _ when i=0 -> safe n [] l
+      | x::l' ->
+        if n > 0
+        then x :: direct (i-1) (n-1) l'
+        else []
+    and safe n acc l = match l with
+      | [] -> List.rev acc
+      | _ when n=0 -> List.rev acc
+      | x::l' -> safe (n-1) (x::acc) l'
+    in
+    direct 500 n l
+
+  let map f l =
+    let rec direct f i l = match l with
+      | [] -> []
+      | [x] -> [f x]
+      | [x1;x2] -> let y1 = f x1 in [y1; f x2]
+      | [x1;x2;x3] -> let y1 = f x1 in let y2 = f x2 in [y1; y2; f x3]
+      | _ when i=0 -> CCList.rev (CCList.rev_map f l)
+      | x1::x2::x3::x4::l' ->
+        let y1 = f x1 in
+        let y2 = f x2 in
+        let y3 = f x3 in
+        let y4 = f x4 in
+        y1 :: y2 :: y3 :: y4 :: direct f (i-1) l'
+    in
+    direct f 500 l
+
+  let all_some l =
+    try Some (map (function Some x -> x | None -> raise Exit) l)
+    with Exit -> None
+
+  let mapi f l =
+    let r = ref 0 in
+    map
+      (fun x ->
+         let y = f !r x in
+         r := !r+1; y
+      ) l
+
+  let find_map f l =
+    let rec aux f = function
+      | [] -> None
+      | x::l' ->
+        match f x with
+          | Some _ as res -> res
+          | None -> aux f l'
+    in aux f l
+
+  let filter_map f l =
+    let rec recurse acc l = match l with
+      | [] -> List.rev acc
+      | x::l' ->
+        let acc' = match f x with | None -> acc | Some y -> y::acc in
+        recurse acc' l'
+    in recurse [] l
+
+  let fold_left = CCList.fold_left
+
+  let direct_depth_append_ = 10_000
+
+  let append l1 l2 =
+    let rec direct i l1 l2 = match l1 with
+      | [] -> l2
+      | _ when i=0 -> safe l1 l2
+      | x::l1' -> x :: direct (i-1) l1' l2
+    and safe l1 l2 =
+      CCList.rev_append (List.rev l1) l2
+    in
+    match l1 with
+    | [] -> l2
+    | [x] -> x::l2
+    | [x;y] -> x::y::l2
+    | _ -> direct direct_depth_append_ l1 l2
+
+  let (@) = append
+
+  let flat_map f l =
+    let rec aux f l kont = match l with
+      | [] -> kont []
+      | x::l' ->
+        let y = f x in
+        let kont' tail = match y with
+          | [] -> kont tail
+          | [x] -> kont (x :: tail)
+          | [x;y] -> kont (x::y::tail)
+          | l -> kont (append l tail)
+        in
+        aux f l' kont'
+    in
+    aux f l (fun l->l)
+end
+
+
+type 'value exposed_error =
+  | Decoder_error of string * 'value option
+  | Decoder_errors of 'value exposed_error list
+  | Decoder_tag of string * 'value exposed_error
+
+type ('good, 'bad) result = ('good, 'bad) My_result.t = Ok of 'good | Error of 'bad
+
+type ('value, 'a) exposed_runner_decoder = { run : 'value -> ('a, 'value exposed_error) result }
+
+
+module RunnerDecoder  = struct
+  type value = record_item
+  let pp fmt expr = Format.fprintf fmt "@[%s@]" (Yojson.Basic.to_string @@ Itr_ast_json_pp.record_item_to_json expr)
+
+  type error = value exposed_error
+
+  let rec pp_error fmt = function
+    | Decoder_error (msg, Some t) -> Format.fprintf fmt "@[%s, but got@ @[%a@]@]" msg pp t
+    | Decoder_error (msg, None) -> Format.fprintf fmt "@[%s@]" msg
+    | Decoder_errors errors ->
+      let errors_trunc = My_list.take 5 errors in
+      let not_shown = List.length errors - 5 in
+      Format.fprintf fmt "@[%a@ %s@]"
+        (Format.pp_print_list ~pp_sep:Format.pp_print_space pp_error) errors_trunc
+        (if not_shown > 0 then Printf.sprintf "(...%d errors not shown...)" (Z.to_int not_shown) else "")
+    | Decoder_tag (msg, error) ->
+      Format.fprintf fmt "@[<2>%s:@ @[%a@]@]"
+        msg
+        pp_error error
+
+
+      let of_file _file =
+
+         Error "not supported"
+
+      let get_string = function
+        | Rec_value (Value (Literal (String value))) -> Some value
+        | _ -> None
+
+      let get_int = function
+        | Rec_value (Value (Literal (Int value))) -> Some value
+        | _ -> None
+
+      let get_float = function
+        | Rec_value (Value (Literal (Float value))) -> Some value
+        | Rec_value (Value (Literal (Int value))) -> Some (Q.of_bigint value)
+        | _ -> None
+
+      let get_bool = function
+        |  Rec_value (Value (Literal (Bool value))) -> Some value
+        | _ -> None
+
+      let get_null = function
+        | _ -> None
+
+      let get_list : value -> value list option = function
+       (* | `List l -> Some l *)
+        | _ -> None
+    (* use this as record assoc?*)
+      let get_key_value_pairs : value -> (value * value) list option = function
+      (*   | `Assoc assoc -> Some (List.map (fun (key, value) -> (`String key, value)) assoc) *)
+        | _ -> None
+
+      let to_list values = Rec_value (Value (Literal LiteralNone))
+
+  let string_of_error e : string =
+    Format.asprintf "@[<2>%a@?@]" pp_error e
+
+  let tag_error (msg : string) (error : error) : error =
+    Decoder_tag (msg, error)
+
+  let tag_errors (msg : string) (errors : error list) : error =
+    Decoder_tag (msg, Decoder_errors errors)
+
+  let merge_errors e1 e2 =
+    match e1, e2 with
+    | Decoder_errors e1s, Decoder_errors e2s -> Decoder_errors (e1s @ e2s)
+    | Decoder_errors e1s, _ -> Decoder_errors (e1s @ [e2])
+    | _, Decoder_errors e2s -> Decoder_errors ([e1] @ e2s )
+    | _ -> Decoder_errors [e1; e2]
+
+  let combine_errors (results : ('a, error) result list) : ('a list, error list) result =
+    let rec aux combined =
+      function
+      | [] ->
+        (match combined with
+         | Ok xs -> Ok (List.rev xs)
+         | Error es -> Error (List.rev es))
+      | result :: rest ->
+        let combined =
+          match result, combined with
+          | Ok x, Ok xs -> Ok (x :: xs)
+          | Error e, Error es -> Error (e :: es)
+          | Error e, Ok _ -> Error [e]
+          | Ok _, Error es -> Error es
+        in
+        aux combined rest
+    in
+    aux (Ok []) results
+
+  (* let of_string : string -> (value, error) result =
+    fun string ->
+    of_string string
+    |> My_result.map_err (fun msg ->
+        (Decoder_tag ("Json parse error", Decoder_error (msg, None)))
+      ) *)
+
+  type 'a runner_decoder = (value, 'a) exposed_runner_decoder
+
+  let succeed x =
+    { run = fun _ -> Ok x }
+
+  let fail msg =
+    { run = fun input -> Error (Decoder_error (msg, Some input)) }
+
+  let fail_with error =
+    { run = fun _ -> Error error }
+
+  let from_result = function
+    | Ok ok -> succeed ok
+    | Error error -> fail_with error
+
+  let value =
+    { run = fun input -> Ok input }
+
+  let map f runner_decoder =
+    { run = fun input -> My_result.Infix.(runner_decoder.run input >|= f) }
+
+  let apply : ('a -> 'b) runner_decoder -> 'a runner_decoder -> 'b runner_decoder =
+    fun f runner_decoder ->
+    { run =
+        fun input ->
+          match f.run input, runner_decoder.run input with
+          | Error e1, Error e2 -> Error (merge_errors e1 e2)
+          | Error e, _ -> Error e
+          | _, Error e -> Error e
+          | Ok g, Ok x -> Ok (g x)
+    }
+
+  let and_then (f : 'a -> 'b runner_decoder) (runner_decoder : 'a runner_decoder) : 'b runner_decoder =
+    { run = fun input ->
+          My_result.Infix.(
+            runner_decoder.run input >>= fun result ->
+            (f result).run input)
+    }
+
+  let fix (f : 'a runner_decoder -> 'a runner_decoder) : 'a runner_decoder =
+    let rec p = lazy (f r)
+    and r = { run = fun value -> (Lazy.force p).run value }
+    in
+    r
+
+  module Infix = struct
+    let (>|=) x f = map f x
+    let (>>=) x f = and_then f x
+    let (<*>) f x = apply f x
+    let (let*) = (>>=)
+    let (let+) = (>|=)
+  end
+
+  let maybe (runner_decoder : 'a runner_decoder) : 'a option runner_decoder =
+    { run = fun input ->
+          match (runner_decoder.run input) with
+          | Ok result -> Ok (Some result)
+          | Error _ -> Ok None
+    }
+
+  let nullable (runner_decoder : 'a runner_decoder) : 'a option runner_decoder =
+    { run =
+        fun input ->
+          match get_null input with
+          | Some () -> Ok None
+          | None ->
+            runner_decoder.run input
+            |> My_result.map My_opt.return
+            |> My_result.map_err (tag_error "Expected null or")
+    }
+
+  let one_of : (string * 'a runner_decoder) list -> 'a runner_decoder =
+    fun runner_decoders ->
+    let run input =
+      let rec go errors = function
+        | (name, runner_decoder) :: rest ->
+          (match runner_decoder.run input with
+           | Ok result -> Ok result
+           | Error error -> go (tag_errors (Printf.sprintf "%S runner_decoder" name) [ error ] :: errors) rest)
+        | [] ->
+          Error
+            (tag_errors "I tried the following runner_decoders but they all failed" errors)
+      in
+      go [] runner_decoders
+    in { run }
+
+  let primitive_runner_decoder (get_value : value -> 'a option) (message : string) : 'a runner_decoder =
+    { run =
+        fun t ->
+          match get_value t with
+          | Some value -> Ok value
+          | _ -> (fail message).run t
+    }
+
+  let string : string runner_decoder =
+    primitive_runner_decoder get_string "Expected a string"
+
+  let int : Z.t runner_decoder =
+    primitive_runner_decoder get_int "Expected an int"
+
+  let float : real runner_decoder =
+    primitive_runner_decoder get_float "Expected a float"
+
+  let bool : bool runner_decoder =
+    primitive_runner_decoder get_bool "Expected a bool"
+
+  let null : unit runner_decoder =
+    primitive_runner_decoder get_null "Expected a null"
+
+  let list : 'a runner_decoder -> 'a list runner_decoder =
+    fun runner_decoder ->
+    { run =
+        fun t ->
+          match get_list t with
+          | None -> (fail "Expected a list").run t
+          | Some values ->
+            values
+            |> My_list.mapi (fun i x ->
+                runner_decoder.run x
+                |> My_result.map_err
+                  (tag_error (Printf.sprintf "element %i" (Z.to_int i)))
+              )
+            |> combine_errors
+            |> My_result.map_err
+              (tag_errors "while decoding a list")
+    }
+
+  let list_filter : 'a option runner_decoder -> 'a list runner_decoder =
+    fun runner_decoder ->
+    let rec go i = function
+      | [] -> Ok []
+      | v :: vs ->
+        My_result.Infix.(
+          runner_decoder.run v
+          |> My_result.map_err
+            (tag_error (Printf.sprintf "element %i" (Z.to_int i))) >>= function
+          | Some x ->
+            go (i + 1) vs >>= fun xs ->
+            My_result.return (x :: xs)
+          | None -> go (i + 1) vs
+        )
+    in
+    { run =
+        fun t ->
+          match get_list t with
+          | None -> (fail "Expected a list").run t
+          | Some values ->
+            go 0 values
+            |> My_result.map_err (tag_error "while decoding a list")
+    }
+
+  let list_fold_left : ('a -> 'a runner_decoder) -> 'a -> 'a runner_decoder =
+    fun runner_decoder_func init ->
+    {
+      run =
+        fun t ->
+          match get_list t with
+          | None -> (fail "Expected a list").run t
+          | Some values ->
+            values
+            |> My_result.Infix.(My_list.fold_left (fun (acc,i) el ->
+                (acc >>= fun acc ->
+                 (acc |> runner_decoder_func).run el
+                 |> My_result.map_err (tag_error (Printf.sprintf "element %i" i))),Z.to_int ((Z.of_int i)+1))
+              )  (Ok init,0i) |> fst
+            |> My_result.map_err (tag_error "while decoding a list")
+    }
+
+  let field : string -> 'a runner_decoder -> 'a runner_decoder =
+    fun key value_runner_decoder ->
+    { run =
+        fun t ->
+          let value =
+            get_key_value_pairs t
+            |> My_opt.flat_map (My_list.find_map (fun (k, v) ->
+                match get_string k with
+                | Some s when s = key -> Some v
+                | _ -> None
+              ))
+          in
+          match value with
+          | Some value ->
+            value_runner_decoder.run value
+            |> My_result.map_err (tag_error (Printf.sprintf "in field %S" key))
+          | None -> (fail (Printf.sprintf "Expected an object with an attribute %S" key)).run t
+    }
+
+  let field_opt : string -> 'a runner_decoder -> 'a option runner_decoder =
+    fun key value_runner_decoder ->
+    { run =
+        fun t ->
+          let value =
+            get_key_value_pairs t
+            |> My_opt.flat_map (My_list.find_map (fun (k, v) ->
+                match get_string k with
+                | Some s when s = key -> Some v
+                | _ -> None
+              ))
+          in
+          match value with
+          | Some value ->
+            value_runner_decoder.run value
+            |> My_result.map (fun v -> Some v)
+            |> My_result.map_err (tag_error (Printf.sprintf "in field %S" key))
+          | None -> Ok None
+    }
+
+  let single_field : (string -> 'a runner_decoder) -> 'a runner_decoder =
+    fun value_runner_decoder ->
+    { run =
+        fun t ->
+          match get_key_value_pairs t with
+          | Some [(key, value)] ->
+            begin match get_string key with
+              | Some key ->
+                (value_runner_decoder key).run value
+                |> My_result.map_err (tag_error (Printf.sprintf "in field %S" key))
+              | None -> (fail "Expected an object with a string key").run t
+            end
+          | _ -> (fail "Expected an object with a single attribute").run t
+    }
+
+  let index : int -> 'a runner_decoder -> 'a runner_decoder =
+    fun i runner_decoder ->
+    { run =
+        fun t ->
+          match get_list t with
+          | Some l ->
+            let item = List.nth i l
+            in
+            begin match item with
+              | None -> (fail ("expected a list with at least " ^  (Z.to_string i) ^ " elements")).run t
+              | Some item -> runner_decoder.run item
+            end
+          | None -> (fail "Expected a list").run t
+    }
+
+  let uncons (tail : 'a -> 'b runner_decoder) (head : 'a runner_decoder) : 'b runner_decoder =
+    { run =
+        fun value ->
+          match get_list value with
+        | Some (x :: rest) ->
+          My_result.Infix.(
+            head.run x
+            |> My_result.map_err (tag_error "while consuming a list element")
+            >>= fun x ->
+            (tail x).run (to_list rest)
+            |> My_result.map_err (tag_error "after consuming a list element")
+          )
+        | Some [] -> (fail "Expected a non-empty list").run value
+        | None -> (fail "Expected a list").run value
+    }
+
+  let rec at : string list -> 'a runner_decoder -> 'a runner_decoder = fun path runner_decoder ->
+    match path with
+    | [key] -> field key runner_decoder
+    | key :: rest -> field key (at rest runner_decoder)
+    | [] -> fail "Must provide at least one key to 'at'"
+
+  let keys' : 'k runner_decoder -> 'k list runner_decoder =
+    fun key_runner_decoder ->
+    { run =
+        fun value ->
+          match get_key_value_pairs value with
+          | Some assoc ->
+            assoc
+            |> List.map (fun (key, _) -> key_runner_decoder.run key)
+            |> combine_errors
+            |> My_result.map_err
+              (tag_errors "Failed while decoding the keys of an object")
+          | None -> (fail "Expected an object").run value
+    }
+
+  let keys = keys' string
+
+  let key_value_pairs' : 'k runner_decoder -> 'v runner_decoder -> ('k * 'v) list runner_decoder =
+    fun key_runner_decoder value_runner_decoder ->
+    { run =
+        fun value ->
+          match get_key_value_pairs value with
+          | Some assoc ->
+            assoc
+            |> List.map
+              My_result.Infix.(fun (key_val, value_val) ->
+                  key_runner_decoder.run key_val >>= fun key ->
+                  value_runner_decoder.run value_val >|= fun value ->
+                  (key, value)
+                )
+            |> combine_errors
+            |> My_result.map_err
+              (tag_errors "Failed while decoding key-value pairs")
+          | None -> (fail "Expected an object").run value
+    }
+
+  let key_value_pairs value_runner_decoder = key_value_pairs' string value_runner_decoder
+
+  let key_value_pairs_seq' : 'k runner_decoder -> ('k -> 'v runner_decoder) -> 'v list runner_decoder =
+    fun key_runner_decoder value_runner_decoder ->
+    { run =
+        fun value ->
+          match get_key_value_pairs value with
+          | Some assoc ->
+            assoc
+            |> List.map
+              My_result.Infix.(fun (key_val, value_val) ->
+                  key_runner_decoder.run key_val >>= fun key ->
+                  (value_runner_decoder key).run value_val
+                )
+            |> combine_errors
+            |> My_result.map_err
+              (tag_errors "Failed while decoding key-value pairs")
+          | None -> (fail "Expected an object").run value
+    }
+
+  let key_value_pairs_seq value_runner_decoder = key_value_pairs_seq' string value_runner_decoder
+
+  let decode_value (runner_decoder : 'a runner_decoder) (input : value) : ('a, error) result =
+    runner_decoder.run input
+
+  module Pipeline = struct
+    let decode = succeed
+
+    let custom : 'a runner_decoder -> ('a -> 'b) runner_decoder -> 'b runner_decoder =
+      fun customDecoder next ->
+      apply next customDecoder
+
+    let required : string -> 'a runner_decoder -> ('a -> 'b) runner_decoder -> 'b runner_decoder =
+      fun key runner_decoder next ->
+      custom (field key runner_decoder) next
+
+    let required_at : string list -> 'a runner_decoder -> ('a -> 'b) runner_decoder -> 'b runner_decoder =
+      fun path runner_decoder next ->
+      custom (at path runner_decoder) next
+
+    let optional_runner_decoder : value runner_decoder -> 'a runner_decoder -> 'a -> 'a runner_decoder =
+      fun path_runner_decoder val_runner_decoder default ->
+      let null_or runner_decoder =
+        one_of
+          [ ( "non-null", runner_decoder )
+          ; ( "null", null |> map (fun () -> default) )
+          ] in
+      let handle_result : value -> 'a runner_decoder =
+        fun input ->
+          match decode_value path_runner_decoder input with
+          | Ok rawValue ->
+            (* The field was present. *)
+            decode_value (null_or val_runner_decoder) rawValue
+            |> from_result
+          | Error _ ->
+            (* The field was not present. *)
+            succeed default
+      in
+      value |> and_then handle_result
+
+    let optional : string -> 'a runner_decoder -> 'a -> ('a -> 'b) runner_decoder -> 'b runner_decoder =
+      fun key val_runner_decoder default next ->
+      custom (optional_runner_decoder (field key value) val_runner_decoder default) next
+
+    let optional_at : string list -> 'a runner_decoder -> 'a -> ('a -> 'b) runner_decoder -> 'b runner_decoder =
+      fun path val_runner_decoder default next ->
+      custom (optional_runner_decoder (at path value) val_runner_decoder default) next
+  end
+
+  include Infix
+end
+
+[@@@logic]

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -152,13 +152,16 @@ and expr_to_json : expr -> t = function
         ]
 
 
-and record_to_json (items : record) =
+and record_to_json (record : record) =
   let item_to_json ((name : string), (item : record_item)) =
     `Assoc [ ("name", `String name); ("record_item", record_item_to_json item) ]
   in
   `Assoc
     [ ( "Record"
-      , `List (List.map item_to_json (String_map.to_list items |> CCList.rev))
+      , `Assoc [
+      ("name",`String record.name);
+      ("elements",`List (List.map item_to_json (String_map.to_list record.elements |> CCList.rev)))
+      ]
       )
     ]
 

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -263,7 +263,7 @@ let rec instruction_to_json : instruction -> t = function
   | Set { prop; value } ->
       `Assoc
         [ ( "Set"
-          , `Assoc [ ("prop", `String prop); ("value", expr_to_json value) ] )
+          , `Assoc [ ("prop", `String prop); ("value", record_item_to_json value) ] )
         ]
   | Call { variable; call } ->
       `Assoc

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -1,6 +1,7 @@
-[@@@require "yojson"]
-
 [@@@program]
+[@@@require "yojson"]
+[@@@import "itr_ast.iml"]
+[@@@import "../src-core-pp/datetime_json.iml"]
 
 open Format
 open Itr_ast

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -1,0 +1,387 @@
+[@@@require "yojson"]
+
+[@@@program]
+
+open Format
+open Itr_ast
+open Yojson.Basic
+open Datetime_json
+module JU = Yojson.Basic.Util
+
+let datetime_to_json : datetime -> t = function
+  | UTCTimestamp d ->
+      `Assoc [ ("UTCTimestamp", utctimestamp_micro_to_json d) ]
+  | UTCTimeOnly d ->
+      `Assoc [ ("UTCTimeOnly", utctimeonly_micro_to_json d) ]
+  | UTCDateOnly d ->
+      `Assoc [ ("UTCDateOnly", utcdateonly_to_json d) ]
+  | LocalMktDate d ->
+      `Assoc [ ("LocalMktDate", localmktdate_to_json d) ]
+  | MonthYear d ->
+      `Assoc [ ("MonthYear", monthyear_to_json d) ]
+
+
+let rec literal_to_json : literal -> t = function
+  | Bool b ->
+      `Assoc [ ("Bool", `Bool b) ]
+  | Int i ->
+      `Assoc [ ("Int", `String (Z.to_string i)) ]
+  | String s ->
+      `Assoc [ ("String", `String (sprintf "\"%s\"" s)) ]
+  | UnquotedString s ->
+      `Assoc [ ("Unquoted_string", `String s) ]
+  | Float q ->
+      `Assoc [ ("Float", `Float (Q.to_float q)) ]
+  | Coll l ->
+      `Assoc [ ("Coll", `List (List.map expr_to_json l)) ]
+  | LiteralNone ->
+      `Assoc [ ("None", `String "None") ]
+  | Datetime d ->
+      `Assoc [ ("Datetime", datetime_to_json d) ]
+
+
+and value_to_json : value -> t = function
+  | Literal l ->
+      `Assoc [ ("Literal", literal_to_json l) ]
+  | Variable v ->
+      `Assoc [ ("Variable", `String (Var.name v)) ]
+  | MessageValue mv ->
+      `Assoc [ ("Message_value", Message_value.to_json mv) ]
+  | ConnectionRef c ->
+      `Assoc [ ("Connection_ref", Connection_ref.to_json c) ]
+  | TODOHex h ->
+      `Assoc [ ("Hex", `String h) ]
+  | Now ->
+      `Assoc [ ("Now", `String "Now") ]
+  | Counter ->
+      `Assoc [ ("Counter", `String "Counter") ]
+  | ObjectProperty op ->
+      `Assoc
+        [ ( "ObjectProperty"
+          , `Assoc
+              [ ("obj", expr_to_json op.obj)
+              ; ("index", opt_index_to_json op.index)
+              ; ("prop", `String op.prop)
+              ] )
+        ]
+  | Funcall { func; args } ->
+      `Assoc
+        [ ( "Funcall"
+          , `Assoc
+              [ ("name", `String func)
+              ; ("args", `List (List.map expr_to_json args))
+              ] )
+        ]
+  | Record_item ri ->
+      `Assoc [ ("Record_item", record_item_to_json ri) ]
+
+
+and opt_index_to_json : Z.t option -> t = function
+  | None ->
+      `Null
+  | Some i ->
+      `Int (Z.to_int i)
+
+
+and expr_to_json : expr -> t = function
+  | Value v ->
+      `Assoc [ ("Value", value_to_json v) ]
+  | Not e ->
+      `Assoc [ ("Not", expr_to_json e) ]
+  | Arrow { condition; assertion } ->
+      `Assoc
+        [ ( "Arrow"
+          , `Assoc
+              [ ("condition", expr_to_json condition)
+              ; ("assertion", expr_to_json assertion)
+              ] )
+        ]
+  | Or { lhs; rhs } ->
+      `Assoc
+        [ ("Or", `Assoc [ ("lhs", expr_to_json lhs); ("rhs", expr_to_json rhs) ])
+        ]
+  | And { lhs; rhs } ->
+      `Assoc
+        [ ( "And"
+          , `Assoc [ ("lhs", expr_to_json lhs); ("rhs", expr_to_json rhs) ] )
+        ]
+  | Eq { lhs; rhs } ->
+      `Assoc
+        [ ("Eq", `Assoc [ ("lhs", expr_to_json lhs); ("rhs", expr_to_json rhs) ])
+        ]
+  | Like { lhs; rhs } ->
+      `Assoc
+        [ ( "Like"
+          , `Assoc [ ("lhs", expr_to_json lhs); ("rhs", expr_to_json rhs) ] )
+        ]
+  | Cmp { lhs; op; rhs } ->
+      `Assoc
+        [ ( "Cmp"
+          , `Assoc
+              [ ("lhs", expr_to_json lhs)
+              ; ("op", `String op)
+              ; ("rhs", expr_to_json rhs)
+              ] )
+        ]
+  | Add { lhs; op; rhs } ->
+      `Assoc
+        [ ( "Add"
+          , `Assoc
+              [ ("lhs", expr_to_json lhs)
+              ; ("op", `String (Char.escaped op))
+              ; ("rhs", expr_to_json rhs)
+              ] )
+        ]
+  | Mul { lhs; op; rhs } ->
+      `Assoc
+        [ ( "Mul"
+          , `Assoc
+              [ ("lhs", expr_to_json lhs)
+              ; ("op", `String (Char.escaped op))
+              ; ("rhs", expr_to_json rhs)
+              ] )
+        ]
+  | In { el; set } ->
+      `Assoc
+        [ ("In", `Assoc [ ("el", expr_to_json el); ("set", expr_to_json set) ])
+        ]
+
+
+and record_to_json (items : record) =
+  let item_to_json ((name : string), (item : record_item)) =
+    `Assoc [ ("name", `String name); ("record_item", record_item_to_json item) ]
+  in
+  `Assoc
+    [ ( "Record"
+      , `List (List.map item_to_json (String_map.to_list items |> CCList.rev))
+      )
+    ]
+
+
+and record_item_to_json (item : record_item) =
+  match item with
+  | Rec_value value ->
+      `Assoc [ ("Rec_value", expr_to_json value) ]
+  | Rec_record items ->
+      `Assoc [ ("Rec_record", record_to_json items) ]
+  | Rec_repeating_group { num_in_group_field; elements } ->
+      `Assoc
+        [ ( "Rec_repeating_group"
+          , `Assoc
+              [ ("num_in_group_field", `String num_in_group_field)
+              ; ("elements", `List (List.map record_to_json elements))
+              ] )
+        ]
+
+
+let rec instruction_to_json : instruction -> t = function
+  | Break ->
+      `Assoc [ ("Break", `Null) ]
+  | Print e ->
+      `Assoc [ ("Print", expr_to_json e) ]
+  | Run e ->
+      `Assoc [ ("Run", expr_to_json e) ]
+  | Sleep e ->
+      `Assoc [ ("Sleep", expr_to_json e) ]
+  | Assert e ->
+      `Assoc [ ("Assert", expr_to_json e) ]
+  | Fail e ->
+      `Assoc
+        [ ("Fail", match e with None -> `Null | Some e -> expr_to_json e) ]
+  | Return e ->
+      `Assoc
+        [ ("Return", match e with None -> `Null | Some e -> expr_to_json e) ]
+  | Goto l ->
+      `Assoc [ ("Goto", `String l) ]
+  | Label l ->
+      `Assoc [ ("Label", `String l) ]
+  | Disconnect s ->
+      `Assoc [ ("Disconnect", Connection_ref.to_json s) ]
+  | Unset v ->
+      `Assoc [ ("Unset", value_to_json v) ]
+  | Cleanup i ->
+      `Assoc [ ("Cleanup", `List (List.map instruction_to_json i)) ]
+  | OnExpired i ->
+      `Assoc [ ("Onexpired", `List (List.map instruction_to_json i)) ]
+  | ForEach { dataset; instructions } ->
+      `Assoc
+        [ ( "Foreach"
+          , `Assoc
+              [ ("dataset", expr_to_json dataset)
+              ; ( "instructions"
+                , `List (List.map instruction_to_json instructions) )
+              ] )
+        ]
+  | Repeat { ntimes; instructions } ->
+      `Assoc
+        [ ( "Repeat"
+          , `Assoc
+              [ ( "ntimes"
+                , match ntimes with
+                  | None ->
+                      `Null
+                  | Some ntimes ->
+                      expr_to_json ntimes )
+              ; ( "instructions"
+                , `List (List.map instruction_to_json instructions) )
+              ] )
+        ]
+  | Connect { connection; timeout; block } ->
+      `Assoc
+        [ ( "Connect"
+          , `Assoc
+              [ ("connection", Connection_ref.to_json connection)
+              ; ( "timeout"
+                , match timeout with
+                  | None ->
+                      `Null
+                  | Some timeout ->
+                      expr_to_json timeout )
+              ; ("block", `Bool block)
+              ] )
+        ]
+  | Set { prop; value } ->
+      `Assoc
+        [ ( "Set"
+          , `Assoc [ ("prop", `String prop); ("value", expr_to_json value) ] )
+        ]
+  | Call { variable; call } ->
+      `Assoc
+        [ ( "Call"
+          , `Assoc
+              [ ( "variable"
+                , match variable with
+                  | None ->
+                      `Null
+                  | Some v ->
+                      `String (Var.name v) )
+              ; ("call", value_to_json call)
+              ] )
+        ]
+  | Send { variable; template; connection; using; withs } ->
+      `Assoc
+        [ ( "Send"
+          , `Assoc
+              [ ( "variable"
+                , match variable with
+                  | None ->
+                      `Null
+                  | Some variable ->
+                      `String (Var.name variable) )
+              ; ("template", Template.to_json template)
+              ; ("connection", Connection_ref.to_json connection)
+              ; ("using", match using with None -> `Null | Some u -> `String u)
+              ; ( "withs"
+                , match withs with
+                  | None ->
+                      `Null
+                  | Some withs ->
+                      record_to_json withs )
+              ] )
+        ]
+  | ExpectingOf { variable; expecting } ->
+      `Assoc
+        [ ( "ExpectingOf"
+          , `Assoc
+              [ ("variable", `String (Var.name variable))
+              ; ("expecting", expecting_to_json expecting)
+              ] )
+        ]
+  | Template { variable; template; connection; using } ->
+      `Assoc
+        [ ( "Template"
+          , `Assoc
+              [ ( "variable"
+                , match variable with
+                  | None ->
+                      `Null
+                  | Some variable ->
+                      `String (Var.name variable) )
+              ; ("template", Template.to_json template)
+              ; ("connection", Connection_ref.to_json connection)
+              ; ("using", match using with None -> `Null | Some u -> `String u)
+              ] )
+        ]
+  | Receive { variable; connection; timeout; where; expecting } ->
+      `Assoc
+        [ ( "Receive"
+          , `Assoc
+              [ ( "variable"
+                , match variable with
+                  | None ->
+                      `Null
+                  | Some variable ->
+                      `String (Var.name variable) )
+              ; ("connection", Connection_ref.to_json connection)
+              ; ( "timeout"
+                , match timeout with
+                  | None ->
+                      `Null
+                  | Some timeout ->
+                      expr_to_json timeout )
+              ; ("where", expr_to_json where)
+              ; ( "expecting"
+                , match expecting with
+                  | None ->
+                      `Null
+                  | Some e ->
+                      expecting_to_json e )
+              ] )
+        ]
+  | IfThenElse { cond; then_; else_ } ->
+      `Assoc
+        [ ( "IfThenElse"
+          , `Assoc
+              [ ("cond", expr_to_json cond)
+              ; ("then", `List (List.map instruction_to_json then_))
+              ; ("else", `List (List.map instruction_to_json else_))
+              ] )
+        ]
+  | FunctionDef { name; args; body } ->
+      `Assoc
+        [ ( "FunctionDef"
+          , `Assoc
+              [ ("name", `String name)
+              ; ("args", `List (List.map tt_to_json args))
+              ; ("body", `List (List.map instruction_to_json body))
+              ] )
+        ]
+  | Comment text ->
+      `Assoc [ ("Comment", `String text) ]
+
+
+and expecting_to_json (expecting : expecting) =
+  `Assoc
+    [ ( "modifier"
+      , match expecting.modifier with
+        | None ->
+            `Null
+        | Some `Only ->
+            `String "only"
+        | Some `Only_supported ->
+            `String "only supported" )
+    ; ("exprs", `List (List.map expr_to_json expecting.exprs))
+    ]
+
+
+and tt_to_json a =
+  `Assoc
+    [ ( "typed_term"
+      , `Assoc
+          [ ("name", `String a.name)
+          ; ("type", match a.type_ with None -> `Null | Some t -> `String t)
+          ] )
+    ]
+
+
+let instructions_to_json is msgs_of_step =
+  `Assoc
+    [ ( "msgs"
+      , `List
+          (List.map Model_messages_json.json_of_model_msg_opt_def msgs_of_step)
+      )
+    ; ("instructions", `List (List.map instruction_to_json is))
+    ]
+
+
+[@@@logic]

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -169,12 +169,16 @@ and record_item_to_json (item : record_item) =
       `Assoc [ ("Rec_value", expr_to_json value) ]
   | Rec_record items ->
       `Assoc [ ("Rec_record", record_to_json items) ]
-  | Rec_repeating_group { num_in_group_field; elements } ->
+  | Rec_repeating_group { num_in_group_field; elements; name;message_template } ->
       `Assoc
         [ ( "Rec_repeating_group"
           , `Assoc
               [ ("num_in_group_field", `String num_in_group_field)
               ; ("elements", `List (List.map record_to_json elements))
+              ; ("name", `String name)
+              ; ("message_template", match message_template with
+              | None -> `Null
+              | Some message_template -> `String message_template)
               ] )
         ]
 

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -322,7 +322,7 @@ let rec instruction_to_json : instruction -> t = function
               ; ("using", match using with None -> `Null | Some u -> `String u)
               ] )
         ]
-  | Receive { variable; connection; timeout; where; expecting } ->
+  | Receive { variable; connection; timeout; where; expecting; example } ->
       `Assoc
         [ ( "Receive"
           , `Assoc
@@ -346,6 +346,7 @@ let rec instruction_to_json : instruction -> t = function
                       `Null
                   | Some e ->
                       expecting_to_json e )
+              ; ("example", record_to_json example)
               ] )
         ]
   | IfThenElse { cond; then_; else_ } ->

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -185,6 +185,8 @@ and record_item_to_json (item : record_item) =
               ] )
         ]
 
+let field_to_json (f:field ) =
+  `Assoc ["name",`String f.name;"value",record_item_to_json f.value]
 
 let rec instruction_to_json : instruction -> t = function
   | Break ->
@@ -197,6 +199,8 @@ let rec instruction_to_json : instruction -> t = function
       `Assoc [ ("Sleep", expr_to_json e) ]
   | Assert e ->
       `Assoc [ ("Assert", expr_to_json e) ]
+  | Action {name;fields} ->
+      `Assoc ["Action",`Assoc ["name",`String name;"fields",`List (List.map field_to_json fields)]]
   | Fail e ->
       `Assoc
         [ ("Fail", match e with None -> `Null | Some e -> expr_to_json e) ]

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -37,8 +37,8 @@ let rec literal_to_json : literal -> t = function
       `Assoc [ ("Float", `Float (Q.to_float q)) ]
   | Coll l ->
       `Assoc [ ("Coll", `List (List.map expr_to_json l)) ]
-  | MapColl l ->
-      `Assoc [ ("MapColl", `List (List.map expr_pair_to_json l)) ]
+  | MapColl (d,l) ->
+      `Assoc [ ("MapColl", `Assoc["default",expr_to_json d;"elements",`List (List.map expr_pair_to_json l)]) ]
   | LiteralNone ->
       `Assoc [ ("None", `String "None") ]
   | LiteralSome e ->

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -39,6 +39,8 @@ let rec literal_to_json : literal -> t = function
       `Assoc [ ("MapColl", `List (List.map expr_pair_to_json l)) ]
   | LiteralNone ->
       `Assoc [ ("None", `String "None") ]
+  | LiteralSome e ->
+      `Assoc [ ("Some", expr_to_json e) ]
   | Datetime d ->
       `Assoc [ ("Datetime", datetime_to_json d) ]
 

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -20,6 +20,8 @@ let datetime_to_json : datetime -> t = function
       `Assoc [ ("LocalMktDate", localmktdate_to_json d) ]
   | MonthYear d ->
       `Assoc [ ("MonthYear", monthyear_to_json d) ]
+  | Duration d ->
+      `Assoc [ ("Duration", duration_to_json d) ]
 
 
 let rec literal_to_json : literal -> t = function

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -201,6 +201,8 @@ let rec instruction_to_json : instruction -> t = function
       `Assoc [ ("Assert", expr_to_json e) ]
   | Action {name;fields} ->
       `Assoc ["Action",`Assoc ["name",`String name;"fields",`List (List.map field_to_json fields)]]
+  | Message {name;fields} ->
+      `Assoc ["Message",`Assoc ["name",`String name;"fields",`List (List.map field_to_json fields)]]
   | Fail e ->
       `Assoc
         [ ("Fail", match e with None -> `Null | Some e -> expr_to_json e) ]

--- a/itr_ast/itr_ast_json_pp.iml
+++ b/itr_ast/itr_ast_json_pp.iml
@@ -35,11 +35,15 @@ let rec literal_to_json : literal -> t = function
       `Assoc [ ("Float", `Float (Q.to_float q)) ]
   | Coll l ->
       `Assoc [ ("Coll", `List (List.map expr_to_json l)) ]
+  | MapColl l ->
+      `Assoc [ ("MapColl", `List (List.map expr_pair_to_json l)) ]
   | LiteralNone ->
       `Assoc [ ("None", `String "None") ]
   | Datetime d ->
       `Assoc [ ("Datetime", datetime_to_json d) ]
 
+and expr_pair_to_json : expr * expr -> t = function
+  | e1,e2 -> `Assoc ["key",expr_to_json e1;"value",expr_to_json e2]
 
 and value_to_json : value -> t = function
   | Literal l ->

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -1,6 +1,6 @@
-[@@@import "itr_ast.iml"]
-
 [@@@program]
+[@@@import "itr_ast.iml"]
+[@@@import "../src-core-pp/encode_datetime.iml"]
 
 open Format
 open Itr_ast

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -206,6 +206,8 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
         ntimes
         (list ~sep:(return "@,") instruction_pp)
         instructions
+  | Action _ ->
+        ()
   | Connect { connection; timeout; block } ->
       let noblock = if block then "" else "noblock" in
       fprintf

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -1,0 +1,358 @@
+[@@@import "itr_ast.iml"]
+
+[@@@program]
+
+open Format
+open Itr_ast
+open Encode_datetime
+
+let datetime_pp (ppf : formatter) : datetime -> unit = function
+  | UTCTimestamp d ->
+      fprintf ppf "%s" (encode_UTCTimestamp_micro d)
+  | UTCTimeOnly d ->
+      fprintf ppf "%s" (encode_UTCTimeOnly_micro d)
+  | UTCDateOnly d ->
+      fprintf ppf "%s" (encode_UTCDateOnly d)
+  | LocalMktDate d ->
+      fprintf ppf "%s" (encode_LocalMktDate d)
+  | MonthYear d ->
+      fprintf ppf "%s" (encode_MonthYear d)
+
+
+let rec literal_pp (ppf : formatter) : literal -> unit = function
+  | Bool true ->
+      fprintf ppf "true"
+  | Bool false ->
+      fprintf ppf "false"
+  | Int i ->
+      fprintf ppf "%s" (Z.to_string i)
+  | String s ->
+      fprintf ppf "\"%s\"" (Caml.String.escaped s)
+  | UnquotedString s ->
+      fprintf ppf "%s" s
+  | Float q ->
+      fprintf ppf "%s" (Q.to_string q)
+  | Coll l ->
+      fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pp) l
+  | LiteralNone ->
+      fprintf ppf "None"
+  | Datetime d ->
+      fprintf ppf "%a" datetime_pp d
+
+
+and value_pp (ppf : formatter) : value -> unit = function
+  | Literal l ->
+      literal_pp ppf l
+  | Variable v ->
+      fprintf ppf "%a" Var.pp v
+  | MessageValue mv ->
+      fprintf ppf "%a" Message_value.pp mv
+  | ConnectionRef c ->
+      fprintf ppf "%a" Connection_ref.pp c
+  | TODOHex h ->
+      fprintf ppf "%s" h
+  | Now ->
+      fprintf ppf "Now"
+  | Counter ->
+      fprintf ppf "Counter"
+  | ObjectProperty op ->
+      fprintf ppf "%a%a.%s" expr_pp_parens op.obj opt_index_pp op.index op.prop
+  | Funcall { func; args } ->
+      fprintf ppf "%s(%a)" func CCFormat.(list ~sep:(return ",") expr_pp) args
+  | Record_item ri ->
+      record_item_pp ppf ri
+
+
+and opt_index_pp (ppf : formatter) : Z.t option -> unit = function
+  | None ->
+      ()
+  | Some i ->
+      fprintf ppf "[%i]" (Z.to_int i)
+
+
+and expr_pp (ppf : formatter) : expr -> unit = function
+  | Value v ->
+      fprintf ppf "%a" value_pp v
+  | Not e ->
+      fprintf ppf "!%a" expr_pp_parens e
+  | Arrow { condition; assertion } ->
+      fprintf ppf "%a->%a" expr_pp_parens condition expr_pp_parens assertion
+  | Or { lhs; rhs } ->
+      fprintf ppf "%a || %a" expr_pp_parens lhs expr_pp_parens rhs
+  | And { lhs; rhs } ->
+      fprintf ppf "%a && %a" expr_pp_parens lhs expr_pp_parens rhs
+  | Eq { lhs; rhs } ->
+      fprintf ppf "%a = %a" expr_pp_parens lhs expr_pp_parens rhs
+  | Like { lhs; rhs } ->
+      fprintf ppf "%a like %a" expr_pp_parens lhs expr_pp_parens rhs
+  | Cmp { lhs; op; rhs } ->
+      fprintf ppf "%a %s %a" expr_pp_parens lhs op expr_pp_parens rhs
+  | Add { lhs; op; rhs } ->
+      fprintf ppf "%a %c %a" expr_pp_parens lhs op expr_pp_parens rhs
+  | Mul { lhs; op; rhs } ->
+      fprintf ppf "%a %c %a" expr_pp_parens lhs op expr_pp_parens rhs
+  | In { el; set } ->
+      fprintf ppf "%a in %a" expr_pp_parens el expr_pp_parens set
+
+
+and expr_pp_parens ppf e =
+  match e with
+  | Value _ | Not _ ->
+      expr_pp ppf e
+  | Arrow _ | Or _ | And _ | Eq _ | Like _ | Cmp _ | Add _ | Mul _ | In _ ->
+      fprintf ppf "(%a)" expr_pp e
+
+
+and record_pp (ppf : formatter) (items : record) =
+  let pp_item (ppf : formatter) ((name : string), (item : record_item)) =
+    let open CCFormat in
+    match item with
+    | Rec_value _ ->
+        fprintf ppf "%s = %a;" name record_item_pp item
+    | Rec_record _ ->
+        fprintf ppf "%s %a" name record_item_pp item
+    | Rec_repeating_group _ ->
+        record_item_pp ppf item
+  in
+  fprintf
+    ppf
+    "{@;<1 2>@[<v>%a@]@,}"
+    CCFormat.(list ~sep:(return "@,") pp_item)
+    (String_map.to_list items |> CCList.rev)
+
+
+and record_item_pp (ppf : formatter) (item : record_item) =
+  let open CCFormat in
+  match item with
+  | Rec_value value ->
+      expr_pp ppf value
+  | Rec_record items ->
+      record_pp ppf items
+  | Rec_repeating_group { num_in_group_field; elements } ->
+    ( match elements with
+    | [] ->
+        fprintf ppf "@[<v 2>%s@ [@[<v 1>@ {@,}@]@ ]@]" num_in_group_field
+    | _ ->
+        fprintf
+          ppf
+          "@[<v 2>%s@ [@[<v 1>@ %a@]@ ]@]"
+          num_in_group_field
+          (list ~sep:(return "@ ") record_pp)
+          elements )
+
+
+let rec instruction_pp (ppf : formatter) : instruction -> unit =
+  let open CCFormat in
+  let pp_var_eq_opt fmt = function
+    | None ->
+        ()
+    | Some var ->
+        fprintf fmt "%a = " Var.pp var
+  in
+  let timeout_pp (ppf : formatter) (tmout : expr) : unit =
+    fprintf ppf "with timeout=%a" expr_pp tmout
+  in
+  function
+  | Break ->
+      fprintf ppf "break"
+  | Print e ->
+      fprintf ppf "print %a" expr_pp e
+  | Run e ->
+      fprintf ppf "run %a" expr_pp e
+  | Sleep e ->
+      fprintf ppf "sleep %a" expr_pp e
+  | Assert e ->
+      fprintf ppf "assert %a" expr_pp e
+  | Fail e ->
+      fprintf ppf "fail %a" (some expr_pp) e
+  | Return e ->
+      fprintf ppf "return %a" (some expr_pp) e
+  | Goto l ->
+      fprintf ppf "goto \"%s\"" l
+  | Label l ->
+      fprintf ppf "label \"%s\":" l
+  | Disconnect s ->
+      fprintf ppf "disconnect %a" Connection_ref.pp s
+  | Unset v ->
+      fprintf ppf "unset %a" value_pp v
+  | Cleanup i ->
+      fprintf
+        ppf
+        "cleanup@[<v>@,{@,%a@,}@,@]"
+        (list ~sep:(return "@,") instruction_pp)
+        i
+  | OnExpired i ->
+      fprintf
+        ppf
+        "onexpired@[<v>@,{@,%a@,}@,@]"
+        (list ~sep:(return "@,") instruction_pp)
+        i
+  | ForEach { dataset; instructions } ->
+      fprintf
+        ppf
+        "@[<v>for each row in dataset %a@,@[<v 2>{@,%a@]@,}@]"
+        expr_pp
+        dataset
+        (list ~sep:(return "@,") instruction_pp)
+        instructions
+  | Repeat { ntimes; instructions } ->
+      fprintf
+        ppf
+        "repeat %a@[<v>@,{@,%a@,}@,@]"
+        (some expr_pp)
+        ntimes
+        (list ~sep:(return "@,") instruction_pp)
+        instructions
+  | Connect { connection; timeout; block } ->
+      let noblock = if block then "" else "noblock" in
+      fprintf
+        ppf
+        "connect %a %a %s"
+        Connection_ref.pp
+        connection
+        (some timeout_pp)
+        timeout
+        noblock
+  | Set { prop; value } ->
+      fprintf ppf "set %s = %a" prop expr_pp_parens value
+  | Call { variable; call } ->
+      fprintf ppf "call %a%a" pp_var_eq_opt variable value_pp call
+  | Send { variable; template; connection; using; withs } ->
+      let using = match using with Some u -> " using " ^ u | None -> "" in
+      fprintf
+        ppf
+        "@[<v>send %a%a to %a%s %a@]"
+        pp_var_eq_opt
+        variable
+        Template.pp
+        template
+        Connection_ref.pp
+        connection
+        using
+        (CCFormat.some record_pp)
+        withs
+  | ExpectingOf { variable; expecting } ->
+      fprintf
+        ppf
+        "@[<v>expectingof %a %a@]"
+        Var.pp
+        variable
+        expecting_pp
+        expecting
+  | Template { variable; template; connection; using } ->
+      let using = match using with Some u -> u | None -> "" in
+      fprintf
+        ppf
+        "template %a%a over %a %s"
+        pp_var_eq_opt
+        variable
+        Template.pp
+        template
+        Connection_ref.pp
+        connection
+        using
+  | Receive { variable; connection; timeout; where; expecting } ->
+      let pp_space_opt pp fmt = function
+        | None ->
+            ()
+        | Some x ->
+            fprintf fmt " %a" pp x
+      in
+      let pp_expecting_opt pp fmt = function
+        | None ->
+            ()
+        | Some x ->
+            fprintf fmt "@ expecting %a" pp x
+      in
+      fprintf
+        ppf
+        "@[<v 2>receive%a from %a%a where %a%a@]"
+        (pp_space_opt Var.pp)
+        variable
+        Connection_ref.pp
+        connection
+        (pp_space_opt timeout_pp)
+        timeout
+        expr_pp
+        where
+        (pp_expecting_opt expecting_pp)
+        expecting
+  | IfThenElse { cond; then_; else_ } ->
+    ( match else_ with
+    | [] ->
+        fprintf ppf "@[<v>if (%a) @,%a@]" expr_pp cond withs_pp then_
+    | else_ ->
+        fprintf
+          ppf
+          "@[<v>if (%a) @,%a else @,%a@]"
+          expr_pp
+          cond
+          withs_pp
+          then_
+          withs_pp
+          else_ )
+  | FunctionDef { name; args; body } ->
+      fprintf
+        ppf
+        "@[<v>function %s(%a)@,%a@]"
+        name
+        typed_term_pp
+        args
+        withs_pp
+        body
+  | Comment text ->
+      fprintf ppf "# %s" text
+
+
+and withs_pp (ppf : formatter) (is : instruction list) =
+  let open CCFormat in
+  fprintf
+    ppf
+    "@[<v>{@;<1 2>@[<v>%a@]@,@]}"
+    (list ~sep:(return "@,") instruction_pp)
+    is
+
+
+and expecting_pp fmt (expecting : expecting) =
+  let open CCFormat in
+  let modifier =
+    match expecting.modifier with
+    | Some `Only ->
+        "only "
+    | Some `Only_supported ->
+        "only supported "
+    | None ->
+        ""
+  in
+  match expecting.exprs with
+  | [] ->
+      fprintf fmt "%s{@,}" modifier
+  | es ->
+      fprintf
+        fmt
+        "%s{@,@[<v 2>  %a@]@,}"
+        modifier
+        (list ~sep:(return "@,") expr_pp)
+        es
+
+
+and typed_term_pp (ppf : formatter) (args : typed_term list) =
+  let open CCFormat in
+  match args with
+  | [] ->
+      fprintf ppf "%s" ""
+  | _ ->
+      fprintf ppf "%a" (list ~sep:(return ",") tt_p) args
+
+
+and tt_p (ppf : formatter) a =
+  match a.type_ with
+  | None ->
+      fprintf ppf "%s" a.name
+  | Some type_ ->
+      fprintf ppf "%s:%s" a.name type_
+
+
+let instructions_pp = CCFormat.(vbox (list instruction_pp ~sep:(return "@,")))
+
+[@@@logic]

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -208,6 +208,8 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
         instructions
   | Action _ ->
         ()
+  | Message _ ->
+        ()
   | Connect { connection; timeout; block } ->
       let noblock = if block then "" else "noblock" in
       fprintf

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -260,7 +260,7 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
         Connection_ref.pp
         connection
         using
-  | Receive { variable; connection; timeout; where; expecting } ->
+  | Receive { variable; connection; timeout; where; expecting; _ } ->
       let pp_space_opt pp fmt = function
         | None ->
             ()

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -17,6 +17,8 @@ let datetime_pp (ppf : formatter) : datetime -> unit = function
     fprintf ppf "%s" (encode_LocalMktDate d)
   | MonthYear d ->
     fprintf ppf "%s" (encode_MonthYear d)
+  | Duration d -> 
+    fprintf ppf "%s" (encode_Duration d)
 
 
 let rec literal_pp (ppf : formatter) : literal -> unit = function

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -34,6 +34,8 @@ let rec literal_pp (ppf : formatter) : literal -> unit = function
       fprintf ppf "%s" (Q.to_string q)
   | Coll l ->
       fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pp) l
+  | MapColl l ->
+        fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pair_pp) l
   | LiteralNone ->
       fprintf ppf "None"
   | Datetime d ->
@@ -94,7 +96,8 @@ and expr_pp (ppf : formatter) : expr -> unit = function
   | In { el; set } ->
       fprintf ppf "%a in %a" expr_pp_parens el expr_pp_parens set
 
-
+and expr_pair_pp ppf (e1,e2) =
+    fprintf ppf "%a -> %a" expr_pp e1 expr_pp e2
 and expr_pp_parens ppf e =
   match e with
   | Value _ | Not _ ->

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -17,7 +17,7 @@ let datetime_pp (ppf : formatter) : datetime -> unit = function
     fprintf ppf "%s" (encode_LocalMktDate d)
   | MonthYear d ->
     fprintf ppf "%s" (encode_MonthYear d)
-  | Duration d -> 
+  | Duration d ->
     fprintf ppf "%s" (encode_Duration d)
 
 
@@ -36,8 +36,8 @@ let rec literal_pp (ppf : formatter) : literal -> unit = function
     fprintf ppf "%s" (Q.to_string q)
   | Coll l ->
     fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pp) l
-  | MapColl l ->
-    fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pair_pp) l
+  | MapColl (d,l) ->
+    fprintf ppf "default:%a@, %a" expr_pp d CCFormat.(list ~sep:(return " ") expr_pair_pp) l
   | LiteralNone ->
     fprintf ppf "None"
   | LiteralSome e ->

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -8,104 +8,104 @@ open Encode_datetime
 
 let datetime_pp (ppf : formatter) : datetime -> unit = function
   | UTCTimestamp d ->
-      fprintf ppf "%s" (encode_UTCTimestamp_micro d)
+    fprintf ppf "%s" (encode_UTCTimestamp_micro d)
   | UTCTimeOnly d ->
-      fprintf ppf "%s" (encode_UTCTimeOnly_micro d)
+    fprintf ppf "%s" (encode_UTCTimeOnly_micro d)
   | UTCDateOnly d ->
-      fprintf ppf "%s" (encode_UTCDateOnly d)
+    fprintf ppf "%s" (encode_UTCDateOnly d)
   | LocalMktDate d ->
-      fprintf ppf "%s" (encode_LocalMktDate d)
+    fprintf ppf "%s" (encode_LocalMktDate d)
   | MonthYear d ->
-      fprintf ppf "%s" (encode_MonthYear d)
+    fprintf ppf "%s" (encode_MonthYear d)
 
 
 let rec literal_pp (ppf : formatter) : literal -> unit = function
   | Bool true ->
-      fprintf ppf "true"
+    fprintf ppf "true"
   | Bool false ->
-      fprintf ppf "false"
+    fprintf ppf "false"
   | Int i ->
-      fprintf ppf "%s" (Z.to_string i)
+    fprintf ppf "%s" (Z.to_string i)
   | String s ->
-      fprintf ppf "\"%s\"" (Caml.String.escaped s)
+    fprintf ppf "\"%s\"" (Caml.String.escaped s)
   | UnquotedString s ->
-      fprintf ppf "%s" s
+    fprintf ppf "%s" s
   | Float q ->
-      fprintf ppf "%s" (Q.to_string q)
+    fprintf ppf "%s" (Q.to_string q)
   | Coll l ->
-      fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pp) l
+    fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pp) l
   | MapColl l ->
-        fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pair_pp) l
+    fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pair_pp) l
   | LiteralNone ->
-      fprintf ppf "None"
+    fprintf ppf "None"
   | LiteralSome e ->
-      fprintf ppf "Some %a" expr_pp e
+    fprintf ppf "Some %a" expr_pp e
   | Datetime d ->
-      fprintf ppf "%a" datetime_pp d
+    fprintf ppf "%a" datetime_pp d
 
 
 and value_pp (ppf : formatter) : value -> unit = function
   | Literal l ->
-      literal_pp ppf l
+    literal_pp ppf l
   | Variable v ->
-      fprintf ppf "%a" Var.pp v
+    fprintf ppf "%a" Var.pp v
   | MessageValue mv ->
-      fprintf ppf "%a" Message_value.pp mv
+    fprintf ppf "%a" Message_value.pp mv
   | ConnectionRef c ->
-      fprintf ppf "%a" Connection_ref.pp c
+    fprintf ppf "%a" Connection_ref.pp c
   | TODOHex h ->
-      fprintf ppf "%s" h
+    fprintf ppf "%s" h
   | Now ->
-      fprintf ppf "Now"
+    fprintf ppf "Now"
   | Counter ->
-      fprintf ppf "Counter"
+    fprintf ppf "Counter"
   | ObjectProperty op ->
-      fprintf ppf "%a%a.%s" expr_pp_parens op.obj opt_index_pp op.index op.prop
+    fprintf ppf "%a%a.%s" expr_pp_parens op.obj opt_index_pp op.index op.prop
   | Funcall { func; args } ->
-      fprintf ppf "%s(%a)" func CCFormat.(list ~sep:(return ",") expr_pp) args
+    fprintf ppf "%s(%a)" func CCFormat.(list ~sep:(return ",") expr_pp) args
   | Record_item ri ->
-      record_item_pp ppf ri
+    record_item_pp ppf ri
 
 
 and opt_index_pp (ppf : formatter) : Z.t option -> unit = function
   | None ->
-      ()
+    ()
   | Some i ->
-      fprintf ppf "[%i]" (Z.to_int i)
+    fprintf ppf "[%i]" (Z.to_int i)
 
 
 and expr_pp (ppf : formatter) : expr -> unit = function
   | Value v ->
-      fprintf ppf "%a" value_pp v
+    fprintf ppf "%a" value_pp v
   | Not e ->
-      fprintf ppf "!%a" expr_pp_parens e
+    fprintf ppf "!%a" expr_pp_parens e
   | Arrow { condition; assertion } ->
-      fprintf ppf "%a->%a" expr_pp_parens condition expr_pp_parens assertion
+    fprintf ppf "%a->%a" expr_pp_parens condition expr_pp_parens assertion
   | Or { lhs; rhs } ->
-      fprintf ppf "%a || %a" expr_pp_parens lhs expr_pp_parens rhs
+    fprintf ppf "%a || %a" expr_pp_parens lhs expr_pp_parens rhs
   | And { lhs; rhs } ->
-      fprintf ppf "%a && %a" expr_pp_parens lhs expr_pp_parens rhs
+    fprintf ppf "%a && %a" expr_pp_parens lhs expr_pp_parens rhs
   | Eq { lhs; rhs } ->
-      fprintf ppf "%a = %a" expr_pp_parens lhs expr_pp_parens rhs
+    fprintf ppf "%a = %a" expr_pp_parens lhs expr_pp_parens rhs
   | Like { lhs; rhs } ->
-      fprintf ppf "%a like %a" expr_pp_parens lhs expr_pp_parens rhs
+    fprintf ppf "%a like %a" expr_pp_parens lhs expr_pp_parens rhs
   | Cmp { lhs; op; rhs } ->
-      fprintf ppf "%a %s %a" expr_pp_parens lhs op expr_pp_parens rhs
+    fprintf ppf "%a %s %a" expr_pp_parens lhs op expr_pp_parens rhs
   | Add { lhs; op; rhs } ->
-      fprintf ppf "%a %c %a" expr_pp_parens lhs op expr_pp_parens rhs
+    fprintf ppf "%a %c %a" expr_pp_parens lhs op expr_pp_parens rhs
   | Mul { lhs; op; rhs } ->
-      fprintf ppf "%a %c %a" expr_pp_parens lhs op expr_pp_parens rhs
+    fprintf ppf "%a %c %a" expr_pp_parens lhs op expr_pp_parens rhs
   | In { el; set } ->
-      fprintf ppf "%a in %a" expr_pp_parens el expr_pp_parens set
+    fprintf ppf "%a in %a" expr_pp_parens el expr_pp_parens set
 
 and expr_pair_pp ppf (e1,e2) =
-    fprintf ppf "%a -> %a" expr_pp e1 expr_pp e2
+  fprintf ppf "%a -> %a" expr_pp e1 expr_pp e2
 and expr_pp_parens ppf e =
   match e with
   | Value _ | Not _ ->
-      expr_pp ppf e
+    expr_pp ppf e
   | Arrow _ | Or _ | And _ | Eq _ | Like _ | Cmp _ | Add _ | Mul _ | In _ ->
-      fprintf ppf "(%a)" expr_pp e
+    fprintf ppf "(%a)" expr_pp e
 
 
 and record_pp (ppf : formatter) (items : record) =
@@ -113,11 +113,11 @@ and record_pp (ppf : formatter) (items : record) =
     let open CCFormat in
     match item with
     | Rec_value _ ->
-        fprintf ppf "%s = %a;" name record_item_pp item
+      fprintf ppf "%s = %a;" name record_item_pp item
     | Rec_record _ ->
-        fprintf ppf "%s %a" name record_item_pp item
+      fprintf ppf "%s %a" name record_item_pp item
     | Rec_repeating_group _ ->
-        record_item_pp ppf item
+      record_item_pp ppf item
   in
   fprintf
     ppf
@@ -130,14 +130,33 @@ and record_item_pp (ppf : formatter) (item : record_item) =
   let open CCFormat in
   match item with
   | Rec_value value ->
-      expr_pp ppf value
+    expr_pp ppf value
   | Rec_record items ->
-      record_pp ppf items
+    record_pp ppf items
   | Rec_repeating_group { num_in_group_field; elements;_ } ->
     ( match elements with
-    | [] ->
+      | [] ->
         fprintf ppf "@[<v 2>%s@ [@[<v 1>@ {@,}@]@ ]@]" num_in_group_field
-    | _ ->
+      | _ ->
+        fprintf
+          ppf
+          "@[<v 2>%s@ [@[<v 1>@ %a@]@ ]@]"
+          num_in_group_field
+          (list ~sep:(return "@ ") record_pp)
+          elements )
+
+and record_item_pp_parens (ppf : formatter) (item : record_item) =
+  let open CCFormat in
+  match item with
+  | Rec_value value ->
+    expr_pp_parens ppf value
+  | Rec_record items ->
+    record_pp ppf items
+  | Rec_repeating_group { num_in_group_field; elements;_ } ->
+    ( match elements with
+      | [] ->
+        fprintf ppf "@[<v 2>%s@ [@[<v 1>@ {@,}@]@ ]@]" num_in_group_field
+      | _ ->
         fprintf
           ppf
           "@[<v 2>%s@ [@[<v 1>@ %a@]@ ]@]"
@@ -150,147 +169,147 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
   let open CCFormat in
   let pp_var_eq_opt fmt = function
     | None ->
-        ()
+      ()
     | Some var ->
-        fprintf fmt "%a = " Var.pp var
+      fprintf fmt "%a = " Var.pp var
   in
   let timeout_pp (ppf : formatter) (tmout : expr) : unit =
     fprintf ppf "with timeout=%a" expr_pp tmout
   in
   function
   | Break ->
-      fprintf ppf "break"
+    fprintf ppf "break"
   | Print e ->
-      fprintf ppf "print %a" expr_pp e
+    fprintf ppf "print %a" expr_pp e
   | Run e ->
-      fprintf ppf "run %a" expr_pp e
+    fprintf ppf "run %a" expr_pp e
   | Sleep e ->
-      fprintf ppf "sleep %a" expr_pp e
+    fprintf ppf "sleep %a" expr_pp e
   | Assert e ->
-      fprintf ppf "assert %a" expr_pp e
+    fprintf ppf "assert %a" expr_pp e
   | Fail e ->
-      fprintf ppf "fail %a" (some expr_pp) e
+    fprintf ppf "fail %a" (some expr_pp) e
   | Return e ->
-      fprintf ppf "return %a" (some expr_pp) e
+    fprintf ppf "return %a" (some expr_pp) e
   | Goto l ->
-      fprintf ppf "goto \"%s\"" l
+    fprintf ppf "goto \"%s\"" l
   | Label l ->
-      fprintf ppf "label \"%s\":" l
+    fprintf ppf "label \"%s\":" l
   | Disconnect s ->
-      fprintf ppf "disconnect %a" Connection_ref.pp s
+    fprintf ppf "disconnect %a" Connection_ref.pp s
   | Unset v ->
-      fprintf ppf "unset %a" value_pp v
+    fprintf ppf "unset %a" value_pp v
   | Cleanup i ->
-      fprintf
-        ppf
-        "cleanup@[<v>@,{@,%a@,}@,@]"
-        (list ~sep:(return "@,") instruction_pp)
-        i
+    fprintf
+      ppf
+      "cleanup@[<v>@,{@,%a@,}@,@]"
+      (list ~sep:(return "@,") instruction_pp)
+      i
   | OnExpired i ->
-      fprintf
-        ppf
-        "onexpired@[<v>@,{@,%a@,}@,@]"
-        (list ~sep:(return "@,") instruction_pp)
-        i
+    fprintf
+      ppf
+      "onexpired@[<v>@,{@,%a@,}@,@]"
+      (list ~sep:(return "@,") instruction_pp)
+      i
   | ForEach { dataset; instructions } ->
-      fprintf
-        ppf
-        "@[<v>for each row in dataset %a@,@[<v 2>{@,%a@]@,}@]"
-        expr_pp
-        dataset
-        (list ~sep:(return "@,") instruction_pp)
-        instructions
+    fprintf
+      ppf
+      "@[<v>for each row in dataset %a@,@[<v 2>{@,%a@]@,}@]"
+      expr_pp
+      dataset
+      (list ~sep:(return "@,") instruction_pp)
+      instructions
   | Repeat { ntimes; instructions } ->
-      fprintf
-        ppf
-        "repeat %a@[<v>@,{@,%a@,}@,@]"
-        (some expr_pp)
-        ntimes
-        (list ~sep:(return "@,") instruction_pp)
-        instructions
+    fprintf
+      ppf
+      "repeat %a@[<v>@,{@,%a@,}@,@]"
+      (some expr_pp)
+      ntimes
+      (list ~sep:(return "@,") instruction_pp)
+      instructions
   | Action _ ->
-        ()
+    ()
   | Message _ ->
-        ()
+    ()
   | Connect { connection; timeout; block } ->
-      let noblock = if block then "" else "noblock" in
-      fprintf
-        ppf
-        "connect %a %a %s"
-        Connection_ref.pp
-        connection
-        (some timeout_pp)
-        timeout
-        noblock
+    let noblock = if block then "" else "noblock" in
+    fprintf
+      ppf
+      "connect %a %a %s"
+      Connection_ref.pp
+      connection
+      (some timeout_pp)
+      timeout
+      noblock
   | Set { prop; value } ->
-      fprintf ppf "set %s = %a" prop expr_pp_parens value
+    fprintf ppf "set %s = %a" prop record_item_pp_parens value
   | Call { variable; call } ->
-      fprintf ppf "call %a%a" pp_var_eq_opt variable value_pp call
+    fprintf ppf "call %a%a" pp_var_eq_opt variable value_pp call
   | Send { variable; template; connection; using; withs } ->
-      let using = match using with Some u -> " using " ^ u | None -> "" in
-      fprintf
-        ppf
-        "@[<v>send %a%a to %a%s %a@]"
-        pp_var_eq_opt
-        variable
-        Template.pp
-        template
-        Connection_ref.pp
-        connection
-        using
-        (CCFormat.some record_pp)
-        withs
+    let using = match using with Some u -> " using " ^ u | None -> "" in
+    fprintf
+      ppf
+      "@[<v>send %a%a to %a%s %a@]"
+      pp_var_eq_opt
+      variable
+      Template.pp
+      template
+      Connection_ref.pp
+      connection
+      using
+      (CCFormat.some record_pp)
+      withs
   | ExpectingOf { variable; expecting } ->
-      fprintf
-        ppf
-        "@[<v>expectingof %a %a@]"
-        Var.pp
-        variable
-        expecting_pp
-        expecting
+    fprintf
+      ppf
+      "@[<v>expectingof %a %a@]"
+      Var.pp
+      variable
+      expecting_pp
+      expecting
   | Template { variable; template; connection; using } ->
-      let using = match using with Some u -> u | None -> "" in
-      fprintf
-        ppf
-        "template %a%a over %a %s"
-        pp_var_eq_opt
-        variable
-        Template.pp
-        template
-        Connection_ref.pp
-        connection
-        using
+    let using = match using with Some u -> u | None -> "" in
+    fprintf
+      ppf
+      "template %a%a over %a %s"
+      pp_var_eq_opt
+      variable
+      Template.pp
+      template
+      Connection_ref.pp
+      connection
+      using
   | Receive { variable; connection; timeout; where; expecting; _ } ->
-      let pp_space_opt pp fmt = function
-        | None ->
-            ()
-        | Some x ->
-            fprintf fmt " %a" pp x
-      in
-      let pp_expecting_opt pp fmt = function
-        | None ->
-            ()
-        | Some x ->
-            fprintf fmt "@ expecting %a" pp x
-      in
-      fprintf
-        ppf
-        "@[<v 2>receive%a from %a%a where %a%a@]"
-        (pp_space_opt Var.pp)
-        variable
-        Connection_ref.pp
-        connection
-        (pp_space_opt timeout_pp)
-        timeout
-        expr_pp
-        where
-        (pp_expecting_opt expecting_pp)
-        expecting
+    let pp_space_opt pp fmt = function
+      | None ->
+        ()
+      | Some x ->
+        fprintf fmt " %a" pp x
+    in
+    let pp_expecting_opt pp fmt = function
+      | None ->
+        ()
+      | Some x ->
+        fprintf fmt "@ expecting %a" pp x
+    in
+    fprintf
+      ppf
+      "@[<v 2>receive%a from %a%a where %a%a@]"
+      (pp_space_opt Var.pp)
+      variable
+      Connection_ref.pp
+      connection
+      (pp_space_opt timeout_pp)
+      timeout
+      expr_pp
+      where
+      (pp_expecting_opt expecting_pp)
+      expecting
   | IfThenElse { cond; then_; else_ } ->
     ( match else_ with
-    | [] ->
+      | [] ->
         fprintf ppf "@[<v>if (%a) @,%a@]" expr_pp cond withs_pp then_
-    | else_ ->
+      | else_ ->
         fprintf
           ppf
           "@[<v>if (%a) @,%a else @,%a@]"
@@ -301,16 +320,16 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
           withs_pp
           else_ )
   | FunctionDef { name; args; body } ->
-      fprintf
-        ppf
-        "@[<v>function %s(%a)@,%a@]"
-        name
-        typed_term_pp
-        args
-        withs_pp
-        body
+    fprintf
+      ppf
+      "@[<v>function %s(%a)@,%a@]"
+      name
+      typed_term_pp
+      args
+      withs_pp
+      body
   | Comment text ->
-      fprintf ppf "# %s" text
+    fprintf ppf "# %s" text
 
 
 and withs_pp (ppf : formatter) (is : instruction list) =
@@ -327,39 +346,39 @@ and expecting_pp fmt (expecting : expecting) =
   let modifier =
     match expecting.modifier with
     | Some `Only ->
-        "only "
+      "only "
     | Some `Only_supported ->
-        "only supported "
+      "only supported "
     | None ->
-        ""
+      ""
   in
   match expecting.exprs with
   | [] ->
-      fprintf fmt "%s{@,}" modifier
+    fprintf fmt "%s{@,}" modifier
   | es ->
-      fprintf
-        fmt
-        "%s{@,@[<v 2>  %a@]@,}"
-        modifier
-        (list ~sep:(return "@,") expr_pp)
-        es
+    fprintf
+      fmt
+      "%s{@,@[<v 2>  %a@]@,}"
+      modifier
+      (list ~sep:(return "@,") expr_pp)
+      es
 
 
 and typed_term_pp (ppf : formatter) (args : typed_term list) =
   let open CCFormat in
   match args with
   | [] ->
-      fprintf ppf "%s" ""
+    fprintf ppf "%s" ""
   | _ ->
-      fprintf ppf "%a" (list ~sep:(return ",") tt_p) args
+    fprintf ppf "%a" (list ~sep:(return ",") tt_p) args
 
 
 and tt_p (ppf : formatter) a =
   match a.type_ with
   | None ->
-      fprintf ppf "%s" a.name
+    fprintf ppf "%s" a.name
   | Some type_ ->
-      fprintf ppf "%s:%s" a.name type_
+    fprintf ppf "%s:%s" a.name type_
 
 
 let instructions_pp = CCFormat.(vbox (list instruction_pp ~sep:(return "@,")))

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -38,6 +38,8 @@ let rec literal_pp (ppf : formatter) : literal -> unit = function
         fprintf ppf "%a" CCFormat.(list ~sep:(return " ") expr_pair_pp) l
   | LiteralNone ->
       fprintf ppf "None"
+  | LiteralSome e ->
+      fprintf ppf "Some %a" expr_pp e
   | Datetime d ->
       fprintf ppf "%a" datetime_pp d
 

--- a/itr_ast/itr_ast_pp.iml
+++ b/itr_ast/itr_ast_pp.iml
@@ -121,7 +121,7 @@ and record_pp (ppf : formatter) (items : record) =
     ppf
     "{@;<1 2>@[<v>%a@]@,}"
     CCFormat.(list ~sep:(return "@,") pp_item)
-    (String_map.to_list items |> CCList.rev)
+    (String_map.to_list items.elements |> CCList.rev)
 
 
 and record_item_pp (ppf : formatter) (item : record_item) =
@@ -131,7 +131,7 @@ and record_item_pp (ppf : formatter) (item : record_item) =
       expr_pp ppf value
   | Rec_record items ->
       record_pp ppf items
-  | Rec_repeating_group { num_in_group_field; elements } ->
+  | Rec_repeating_group { num_in_group_field; elements;_ } ->
     ( match elements with
     | [] ->
         fprintf ppf "@[<v 2>%s@ [@[<v 1>@ {@,}@]@ ]@]" num_in_group_field

--- a/src-core-pp/parse_base_types.iml
+++ b/src-core-pp/parse_base_types.iml
@@ -11,47 +11,50 @@
 open Numeric;;
 
 let parse_string (str : string) : string option =
-   Some str
+  Some str
 ;;
 
-let parse_lstring (str:string) : LString.t option = 
+let parse_lstring (str:string) : LString.t option =
   Some (LString.of_string str)
 ;;
 
 let parse_symbol (str : string) : string option =
-    Some str
+  Some str
 ;;
 
 let parse_char (str: string) : string option =
-    Some str
+  Some str
 
 let parse_int ( str : string ) : int option =
-    if String.get str (Z.to_int 0) = '+' then None else
+  if String.get str (Z.to_int 0) = '+' then None else
     try
-        Some  (Z.of_int (int_of_string str))
+      Some  (Z.of_int (int_of_string str))
     with _ -> None
 ;;
 
 let parse_bool ( str : string) : bool option =
-    match str with
-    | "Y" -> Some true
-    | "N" -> Some false
-    | _ -> None
+  match str with
+  | "Y" -> Some true
+  | "N" -> Some false
+  | _ -> None
 ;;
 
 let rec pow10 n =
-    if n <= 0 then 1 else 10 * pow10 (n-1)
+  if n <= 0 then 1 else 10 * pow10 (n-1)
 
 (** Convert string to fix_float type. *)
 let parse_float (str: string) : Numeric.fix_float_6 option =
-    if String.get str (Z.to_int 0) = '+' then None else
-    let whole, tail = Scanf.sscanf str "%d%s" (fun w f -> (w,f)) in
-    if (tail = "") || (tail = ".") then Some (Float_6 ( Z.of_int whole * 1000000 )) else
-    if String.get tail (Z.to_int 0) <> '.' then None else
-    let fraction = Scanf.sscanf tail ".%d" (fun t -> t) in
-    let frlen = String.length tail - 1 in
-    if frlen <= 6 then
-    Some (Float_6 (Z.of_int whole * 1000000 + Z.of_int fraction * pow10 (6 - frlen)))
-    else None
+  if String.get str (Z.to_int 0) = '+' then None else
+    try let whole, tail =
+          Scanf.sscanf str "%d%s" (fun w f -> (w,f)) in
+      if (tail = "") || (tail = ".") then Some (Float_6 ( Z.of_int whole * 1000000 )) else
+      if String.get tail (Z.to_int 0) <> '.' then None else
+        try let fraction = Scanf.sscanf tail ".%d" (fun t -> t) in
+          let frlen = String.length tail - 1 in
+          if frlen <= 6 then
+            Some (Float_6 (Z.of_int whole * 1000000 + Z.of_int fraction * pow10 (6 - frlen)))
+          else None
+        with _ -> None
+    with _ -> None
 ;;
 [@@@logic]

--- a/src-core-pp/parse_datetime.iml
+++ b/src-core-pp/parse_datetime.iml
@@ -5,7 +5,7 @@
     Copyright (c) 2014 - 2021
 
     parse_datetime.ml
-    
+
 *)
 [@@@import "../src-core/datetime.iml"]
 [@@@program]
@@ -13,168 +13,176 @@ open Datetime;;
 
 
 let parse_UTCDateOnly str =
-    if String.length str <> 8 then None else
-    let year, month, day = Scanf.sscanf str "%04u%02u%02u" 
-        ( fun y m d -> (y,m,d) ) in
-    Some {
+  if String.length str <> 8 then None else
+    try let year, month, day = Scanf.sscanf str "%04u%02u%02u"
+            ( fun y m d -> (y,m,d) ) in
+      Some {
         utc_dateonly_year  = Z.of_int year;
         utc_dateonly_month = Z.of_int month;
         utc_dateonly_day   = Z.of_int day
-    }
+      }
+    with | _ -> None
 ;;
 
 
 let parse_LocalMktDate str =
-    if String.length str <> 8 then None else
-    let year, month, day = Scanf.sscanf str "%04u%02u%02u" 
-        ( fun y m d -> (y,m,d) ) in
-    Some {
+  if String.length str <> 8 then None else
+    try let year, month, day = Scanf.sscanf str "%04u%02u%02u"
+            ( fun y m d -> (y,m,d) ) in
+      Some {
         localmktdate_year  = Z.of_int year;
         localmktdate_month = Z.of_int month;
         localmktdate_day   = Z.of_int day
-    }
+      } with
+    | _ -> None
 ;;
 
 
-let parse_UTCTimeOnly_milli str = 
-    let length = String.length str in
-    if (length <> 8) && (length <> 12) then None else
-    let hours, minutes, seconds, mseconds = 
-        Scanf.sscanf str "%02u:%02u:%02u%s" 
-        ( fun h m s ms -> (
-            let mseconds = if(ms = "") then None 
-                else ( Scanf.sscanf ms ".%03d" (fun x -> Some x) ) in
-            (Z.of_int h,Z.of_int m,Z.of_int s,match mseconds with None -> None | Some c -> Some (Z.of_int c)) ) ) in
-    Some {
+let parse_UTCTimeOnly_milli str =
+  let length = String.length str in
+  if (length <> 8) && (length <> 12) then None else
+    try let hours, minutes, seconds, mseconds =
+          Scanf.sscanf str "%02u:%02u:%02u%s"
+            ( fun h m s ms -> (
+                  let mseconds = if(ms = "") then None
+                    else ( Scanf.sscanf ms ".%03d" (fun x -> Some x) ) in
+                  (Z.of_int h,Z.of_int m,Z.of_int s,match mseconds with None -> None | Some c -> Some (Z.of_int c)) ) ) in
+      Some {
         utc_timeonly_hour    = hours;
         utc_timeonly_minute  = minutes;
         utc_timeonly_second  = seconds;
         utc_timeonly_millisec = mseconds
-    }
+      } with
+    | _ -> None
 ;;
 
-let parse_UTCTimeOnly_micro str = 
-    let length = String.length str in
-    if (length <> 8) && (length <> 15) then None else
-    let hours, minutes, seconds, mseconds = 
-        Scanf.sscanf str "%02u:%02u:%02u%s" 
-        ( fun h m s ms -> (
-            let mseconds = if(ms = "") then None 
-                else ( Scanf.sscanf ms ".%06d" (fun x -> Some x) ) in
-            (Z.of_int h,Z.of_int m,Z.of_int s,match mseconds with None -> None | Some c -> Some (Z.of_int c)) ) ) in
-    Some {
+let parse_UTCTimeOnly_micro str =
+  let length = String.length str in
+  if (length <> 8) && (length <> 15) then None else
+    try let hours, minutes, seconds, mseconds =
+          Scanf.sscanf str "%02u:%02u:%02u%s"
+            ( fun h m s ms -> (
+                  let mseconds = if(ms = "") then None
+                    else ( Scanf.sscanf ms ".%06d" (fun x -> Some x) ) in
+                  (Z.of_int h,Z.of_int m,Z.of_int s,match mseconds with None -> None | Some c -> Some (Z.of_int c)) ) ) in
+      Some {
         utc_timeonly_hour    = hours;
         utc_timeonly_minute  = minutes;
         utc_timeonly_second  = seconds;
         utc_timeonly_microsec = mseconds
-    }
+      } with
+    | _ -> None
 ;;
 
-let parse_UTCTimestamp_milli str = 
-    let length = String.length str in
-    if (length <> 17) && (length <> 21) then None else
-    let date, time = Scanf.sscanf str "%s@-%s" 
-        ( fun d t -> (parse_UTCDateOnly d , parse_UTCTimeOnly_milli t) ) in
-    match date, time with 
-        | (Some date, Some time) -> Some {
-            utc_timestamp_year     = date.utc_dateonly_year;
-            utc_timestamp_month    = date.utc_dateonly_month;
-            utc_timestamp_day      = date.utc_dateonly_day;
-            utc_timestamp_hour     = time.utc_timeonly_hour;
-            utc_timestamp_minute   = time.utc_timeonly_minute;
-            utc_timestamp_second   = time.utc_timeonly_second;
-            utc_timestamp_millisec = time.utc_timeonly_millisec }
-        | _ -> None
+let parse_UTCTimestamp_milli str =
+  let length = String.length str in
+  if (length <> 17) && (length <> 21) then None else
+    try let date, time = Scanf.sscanf str "%s@-%s"
+            ( fun d t -> (parse_UTCDateOnly d , parse_UTCTimeOnly_milli t) ) in
+      match date, time with
+      | (Some date, Some time) -> Some {
+          utc_timestamp_year     = date.utc_dateonly_year;
+          utc_timestamp_month    = date.utc_dateonly_month;
+          utc_timestamp_day      = date.utc_dateonly_day;
+          utc_timestamp_hour     = time.utc_timeonly_hour;
+          utc_timestamp_minute   = time.utc_timeonly_minute;
+          utc_timestamp_second   = time.utc_timeonly_second;
+          utc_timestamp_millisec = time.utc_timeonly_millisec }
+      | _ -> None with
+    | _ -> None
 ;;
 
-let parse_UTCTimestamp_micro str = 
-    let length = String.length str in
-    if (length <> 17) && (length <> 24) then None else
-    let date, time = Scanf.sscanf str "%s@-%s" 
-        ( fun d t -> (parse_UTCDateOnly d , parse_UTCTimeOnly_micro t) ) in
-    match date, time with 
-        | (Some date, Some time) -> Some {
-            utc_timestamp_year     = date.utc_dateonly_year;
-            utc_timestamp_month    = date.utc_dateonly_month;
-            utc_timestamp_day      = date.utc_dateonly_day;
-            utc_timestamp_hour     = time.utc_timeonly_hour;
-            utc_timestamp_minute   = time.utc_timeonly_minute;
-            utc_timestamp_second   = time.utc_timeonly_second;
-            utc_timestamp_microsec = time.utc_timeonly_microsec }
-        | _ -> None
+let parse_UTCTimestamp_micro str =
+  let length = String.length str in
+  if (length <> 17) && (length <> 24) then None else
+    try let date, time = Scanf.sscanf str "%s@-%s"
+            ( fun d t -> (parse_UTCDateOnly d , parse_UTCTimeOnly_micro t) ) in
+      match date, time with
+      | (Some date, Some time) -> Some {
+          utc_timestamp_year     = date.utc_dateonly_year;
+          utc_timestamp_month    = date.utc_dateonly_month;
+          utc_timestamp_day      = date.utc_dateonly_day;
+          utc_timestamp_hour     = time.utc_timeonly_hour;
+          utc_timestamp_minute   = time.utc_timeonly_minute;
+          utc_timestamp_second   = time.utc_timeonly_second;
+          utc_timestamp_microsec = time.utc_timeonly_microsec }
+      | _ -> None
+    with | _ -> None
 ;;
 
 let parse_MonthYear str =
-    let length = String.length str in
-    if (length < 6) then None else
-    let year, month, tail = Scanf.sscanf str "%04u%02u%s" (fun y m t -> (y,m,t)) in
-    let day, week = match tail with
+  let length = String.length str in
+  if (length < 6) then None else
+    try let year, month, tail = Scanf.sscanf str "%04u%02u%s" (fun y m t -> (y,m,t)) in
+      let day, week = match tail with
         | "w1" -> None, Some Week_1
         | "w2" -> None, Some Week_2
         | "w3" -> None, Some Week_3
         | "w4" -> None, Some Week_4
-        | "w5" -> None, Some Week_5       
+        | "w5" -> None, Some Week_5
         | ""   -> None, None
         | day  -> Some (Z.of_string day), None
-        in
-    Some {
+      in
+      Some {
         monthyear_year  = Z.of_int year;
         monthyear_month = Z.of_int month;
         monthyear_day   = day;
         monthyear_week  = week;
-    }
+      } with
+    | _ -> None
 ;;
 
 
 let parse_Duration (str:string) : fix_duration option =
-  let parse_int ( str : string ) : int option = 
-    try  Some (Z.of_string str) 
+  let parse_int ( str : string ) : int option =
+    try  Some (Z.of_string str)
     with _ -> None
   in
   if String.length str > 1 then
-    (let t,v = Scanf.sscanf str "%c%s" (fun t v -> (t,v)) in 
-     match t,v with
-     | 'D',x -> (match parse_int x with 
-         | None -> None 
-         | Some x -> Some (normalise_duration {
-             dur_years    = 0;
-             dur_months   = 0;
-             dur_days     = x;
-             dur_hours    = 0;
-             dur_minutes  = 0;
-             dur_seconds  = 0;
-           }))
-     | 'M',x -> (match parse_int x with 
-         | None -> None 
-         | Some x -> Some (normalise_duration {
-             dur_years    = 0;
-             dur_months   = x;
-             dur_days     = 0;
-             dur_hours    = 0;
-             dur_minutes  = 0;
-             dur_seconds  = 0;
-           }))
-     | 'W',x -> (match parse_int x with 
-         | None -> None 
-         | Some x -> Some (normalise_duration {
-             dur_years    = 0;
-             dur_months   = 0;
-             dur_days     = x*7;
-             dur_hours    = 0;
-             dur_minutes  = 0;
-             dur_seconds  = 0;
-           }))
-     | 'Y',x -> (match parse_int x with 
-         | None -> None 
-         | Some x -> Some (normalise_duration {
-             dur_years    = x;
-             dur_months   = 0;
-             dur_days     = 0;
-             dur_hours    = 0;
-             dur_minutes  = 0;
-             dur_seconds  = 0;
-           }))
-     | _,_ -> None)
-  else None 
+    (try let t,v = Scanf.sscanf str "%c%s" (fun t v -> (t,v)) in
+       match t,v with
+       | 'D',x -> (match parse_int x with
+           | None -> None
+           | Some x -> Some (normalise_duration {
+               dur_years    = 0;
+               dur_months   = 0;
+               dur_days     = x;
+               dur_hours    = 0;
+               dur_minutes  = 0;
+               dur_seconds  = 0;
+             }))
+       | 'M',x -> (match parse_int x with
+           | None -> None
+           | Some x -> Some (normalise_duration {
+               dur_years    = 0;
+               dur_months   = x;
+               dur_days     = 0;
+               dur_hours    = 0;
+               dur_minutes  = 0;
+               dur_seconds  = 0;
+             }))
+       | 'W',x -> (match parse_int x with
+           | None -> None
+           | Some x -> Some (normalise_duration {
+               dur_years    = 0;
+               dur_months   = 0;
+               dur_days     = x*7;
+               dur_hours    = 0;
+               dur_minutes  = 0;
+               dur_seconds  = 0;
+             }))
+       | 'Y',x -> (match parse_int x with
+           | None -> None
+           | Some x -> Some (normalise_duration {
+               dur_years    = x;
+               dur_months   = 0;
+               dur_days     = 0;
+               dur_hours    = 0;
+               dur_minutes  = 0;
+               dur_seconds  = 0;
+             }))
+       | _,_ -> None with
+    | _ -> None)
+  else None
 ;;
 [@@@logic]

--- a/src-core/datetime.iml
+++ b/src-core/datetime.iml
@@ -1,4 +1,4 @@
-(** Implementation of the date/time types and operations. *) 
+(** Implementation of the date/time types and operations. *)
 (**
 
     Imandra Inc.
@@ -31,7 +31,7 @@ let is_leapyear ( year : int ) =
 
 
 (** Days in month helper function *)
-let how_many_days ( month:int)  (year : int ) = 
+let how_many_days ( month:int)  (year : int ) =
   match month with
   | 1     -> 31
   | 2     -> if is_leapyear ( year ) then 29 else 28
@@ -120,14 +120,14 @@ let default_utctimestamp_micro = {
 
 let normalise_utctimestamp_milli ( ts : fix_utctimestamp_milli ) =
   let carry_secs  = calculate_carry ts.utc_timestamp_second 60 0 in
-  let new_minute  = if carry_secs.carry_over then ( ts.utc_timestamp_minute + 1)  else ts.utc_timestamp_minute in 
+  let new_minute  = if carry_secs.carry_over then ( ts.utc_timestamp_minute + 1)  else ts.utc_timestamp_minute in
   let carry_mins  = calculate_carry  new_minute            60 0  in
-  let new_hour    = if carry_mins.carry_over then ( ts.utc_timestamp_hour + 1 )   else ts.utc_timestamp_hour in 
-  let carry_hours = calculate_carry  new_hour               24 0 in 
-  let new_days    = if carry_hours.carry_over then ( ts.utc_timestamp_day + 1 )   else ts.utc_timestamp_day in 
+  let new_hour    = if carry_mins.carry_over then ( ts.utc_timestamp_hour + 1 )   else ts.utc_timestamp_hour in
+  let carry_hours = calculate_carry  new_hour               24 0 in
+  let new_days    = if carry_hours.carry_over then ( ts.utc_timestamp_day + 1 )   else ts.utc_timestamp_day in
   let carry_days  = calculate_carry new_days (1 + (how_many_days ts.utc_timestamp_month ts.utc_timestamp_year )) 1 in
   let new_months  = if carry_days.carry_over then ( ts.utc_timestamp_month + 1 )  else ts.utc_timestamp_month in
-  let carry_months = calculate_carry new_months            13 1 in 
+  let carry_months = calculate_carry new_months            13 1 in
   let new_years   = if carry_months.carry_over then ( ts.utc_timestamp_year + 1 ) else ts.utc_timestamp_year in {
     utc_timestamp_millisec  = ts.utc_timestamp_millisec;
     utc_timestamp_second    = carry_secs.new_field;
@@ -141,14 +141,14 @@ let normalise_utctimestamp_milli ( ts : fix_utctimestamp_milli ) =
 
 let normalise_utctimestamp_micro ( ts : fix_utctimestamp_micro ) =
   let carry_secs  = calculate_carry ts.utc_timestamp_second 60 0 in
-  let new_minute  = if carry_secs.carry_over then ( ts.utc_timestamp_minute + 1)  else ts.utc_timestamp_minute in 
+  let new_minute  = if carry_secs.carry_over then ( ts.utc_timestamp_minute + 1)  else ts.utc_timestamp_minute in
   let carry_mins  = calculate_carry  new_minute            60 0  in
-  let new_hour    = if carry_mins.carry_over then ( ts.utc_timestamp_hour + 1 )   else ts.utc_timestamp_hour in 
-  let carry_hours = calculate_carry  new_hour               24 0 in 
-  let new_days    = if carry_hours.carry_over then ( ts.utc_timestamp_day + 1 )   else ts.utc_timestamp_day in 
+  let new_hour    = if carry_mins.carry_over then ( ts.utc_timestamp_hour + 1 )   else ts.utc_timestamp_hour in
+  let carry_hours = calculate_carry  new_hour               24 0 in
+  let new_days    = if carry_hours.carry_over then ( ts.utc_timestamp_day + 1 )   else ts.utc_timestamp_day in
   let carry_days  = calculate_carry new_days (1 + (how_many_days ts.utc_timestamp_month ts.utc_timestamp_year )) 1 in
   let new_months  = if carry_days.carry_over then ( ts.utc_timestamp_month + 1 )  else ts.utc_timestamp_month in
-  let carry_months = calculate_carry new_months            13 1 in 
+  let carry_months = calculate_carry new_months            13 1 in
   let new_years   = if carry_months.carry_over then ( ts.utc_timestamp_year + 1 ) else ts.utc_timestamp_year in {
     utc_timestamp_microsec  = ts.utc_timestamp_microsec;
     utc_timestamp_second    = carry_secs.new_field;
@@ -162,7 +162,7 @@ let normalise_utctimestamp_micro ( ts : fix_utctimestamp_micro ) =
 
 
 (** Constructor for the UTC timestamp milli  *)
-let make_utctimestamp_milli ( year:int) (month:int) (day:int) (hour:int) (minute:int) (second:int) (millisec:int option) : fix_utctimestamp_milli = 
+let make_utctimestamp_milli ( year:int) (month:int) (day:int) (hour:int) (minute:int) (second:int) (millisec:int option) : fix_utctimestamp_milli =
   normalise_utctimestamp_milli
     {
       utc_timestamp_year      = year;
@@ -176,7 +176,7 @@ let make_utctimestamp_milli ( year:int) (month:int) (day:int) (hour:int) (minute
 ;;
 
 (** Constructor for the UTC timestamp micro  *)
-let make_utctimestamp_micro ( year:int) (month:int) (day:int) (hour:int) (minute:int) (second:int) (microsec:int option) : fix_utctimestamp_micro = 
+let make_utctimestamp_micro ( year:int) (month:int) (day:int) (hour:int) (minute:int) (second:int) (microsec:int option) : fix_utctimestamp_micro =
   normalise_utctimestamp_micro
     {
       utc_timestamp_year      = year;
@@ -198,7 +198,7 @@ let convert_utctimestamp_milli_micro (f1:fix_utctimestamp_milli) : fix_utctimest
     utc_timestamp_hour      = f1.utc_timestamp_hour;
     utc_timestamp_minute    = f1.utc_timestamp_minute;
     utc_timestamp_second    = f1.utc_timestamp_second;
-    utc_timestamp_microsec  = f1.utc_timestamp_millisec;
+    utc_timestamp_microsec  = Option.map (fun x -> x * 1000) f1.utc_timestamp_millisec;
   }
 ;;
 
@@ -210,17 +210,17 @@ let convert_utctimestamp_micro_milli (f1:fix_utctimestamp_micro) : fix_utctimest
     utc_timestamp_hour      = f1.utc_timestamp_hour;
     utc_timestamp_minute    = f1.utc_timestamp_minute;
     utc_timestamp_second    = f1.utc_timestamp_second;
-    utc_timestamp_millisec  = f1.utc_timestamp_microsec;
+    utc_timestamp_millisec  = Option.map (fun x -> x / 1000) f1.utc_timestamp_microsec;
   }
 ;;
 
 (** Checking validity of the values in the UTC timestamp milli *)
 let is_valid_utctimestamp_milli ( ts : fix_utctimestamp_milli ) =
-  0 <= ts.utc_timestamp_year      && ts.utc_timestamp_year    <= 9999 && 
-  1 <= ts.utc_timestamp_month     && ts.utc_timestamp_month   <= 12   && 
-  valid_day ts.utc_timestamp_day ts.utc_timestamp_month ts.utc_timestamp_year  && 
-  0 <= ts.utc_timestamp_hour      && ts.utc_timestamp_hour    <= 23   && 
-  0 <= ts.utc_timestamp_minute    && ts.utc_timestamp_minute  <= 59   && 
+  0 <= ts.utc_timestamp_year      && ts.utc_timestamp_year    <= 9999 &&
+  1 <= ts.utc_timestamp_month     && ts.utc_timestamp_month   <= 12   &&
+  valid_day ts.utc_timestamp_day ts.utc_timestamp_month ts.utc_timestamp_year  &&
+  0 <= ts.utc_timestamp_hour      && ts.utc_timestamp_hour    <= 23   &&
+  0 <= ts.utc_timestamp_minute    && ts.utc_timestamp_minute  <= 59   &&
   0 <= ts.utc_timestamp_second    && ts.utc_timestamp_second  <= 59   && (
     match ts.utc_timestamp_millisec with
     | None -> true
@@ -229,11 +229,11 @@ let is_valid_utctimestamp_milli ( ts : fix_utctimestamp_milli ) =
 
 (** Checking validity of the values in the UTC timestamp micro *)
 let is_valid_utctimestamp_micro ( ts : fix_utctimestamp_micro ) =
-  0 <= ts.utc_timestamp_year      && ts.utc_timestamp_year    <= 9999 && 
-  1 <= ts.utc_timestamp_month     && ts.utc_timestamp_month   <= 12   && 
-  valid_day ts.utc_timestamp_day ts.utc_timestamp_month ts.utc_timestamp_year  && 
-  0 <= ts.utc_timestamp_hour      && ts.utc_timestamp_hour    <= 23   && 
-  0 <= ts.utc_timestamp_minute    && ts.utc_timestamp_minute  <= 59   && 
+  0 <= ts.utc_timestamp_year      && ts.utc_timestamp_year    <= 9999 &&
+  1 <= ts.utc_timestamp_month     && ts.utc_timestamp_month   <= 12   &&
+  valid_day ts.utc_timestamp_day ts.utc_timestamp_month ts.utc_timestamp_year  &&
+  0 <= ts.utc_timestamp_hour      && ts.utc_timestamp_hour    <= 23   &&
+  0 <= ts.utc_timestamp_minute    && ts.utc_timestamp_minute  <= 59   &&
   0 <= ts.utc_timestamp_second    && ts.utc_timestamp_second  <= 59   && (
     match ts.utc_timestamp_microsec with
     | None -> true
@@ -250,7 +250,7 @@ let utctimestamp_Equal_micro_micro ( tOne: fix_utctimestamp_micro) (tTwo : fix_u
 ;;
 
 let utctimestamp_Equal_milli_micro ( tOne: fix_utctimestamp_milli) (tTwo : fix_utctimestamp_micro  ) =
-  (tOne = { 
+  (tOne = {
       utc_timestamp_year      = tTwo.utc_timestamp_year;
       utc_timestamp_month     = tTwo.utc_timestamp_month;
       utc_timestamp_day       = tTwo.utc_timestamp_day;
@@ -259,7 +259,7 @@ let utctimestamp_Equal_milli_micro ( tOne: fix_utctimestamp_milli) (tTwo : fix_u
       utc_timestamp_second    = tTwo.utc_timestamp_second;
       utc_timestamp_millisec = match tTwo.utc_timestamp_microsec with
         | None -> None
-        | Some x -> Some (x/1000)}) 
+        | Some x -> Some (x/1000)})
 ;;
 
 let utctimestamp_Equal_micro_milli ( tOne: fix_utctimestamp_micro) (tTwo : fix_utctimestamp_milli  ) =
@@ -273,14 +273,14 @@ let utctimestamp_Equal_micro_milli ( tOne: fix_utctimestamp_micro) (tTwo : fix_u
     utc_timestamp_millisec = match tOne.utc_timestamp_microsec with
       | None -> None
       | Some x -> Some (x/1000)} = tTwo)
-;; 
+;;
 
 (** UTC Timestamp milli base comparison operator *)
 let utctimestamp_GreaterThan_milli_milli ( tOne: fix_utctimestamp_milli) (tTwo : fix_utctimestamp_milli ) =
   if utctimestamp_Equal_milli_milli tOne tTwo then false
   else
   if tOne.utc_timestamp_year          > tTwo.utc_timestamp_year   then true
-  else if tOne.utc_timestamp_year     < tTwo.utc_timestamp_year   then false 
+  else if tOne.utc_timestamp_year     < tTwo.utc_timestamp_year   then false
   else if tOne.utc_timestamp_month    > tTwo.utc_timestamp_month  then true
   else if tOne.utc_timestamp_month    < tTwo.utc_timestamp_month  then false
   else if tOne.utc_timestamp_day      > tTwo.utc_timestamp_day    then true
@@ -291,8 +291,8 @@ let utctimestamp_GreaterThan_milli_milli ( tOne: fix_utctimestamp_milli) (tTwo :
   else if tOne.utc_timestamp_minute   < tTwo.utc_timestamp_minute then false
   else if tOne.utc_timestamp_second   > tTwo.utc_timestamp_second then true
   else if tOne.utc_timestamp_second   < tTwo.utc_timestamp_second then false
-  else 
-    match tOne.utc_timestamp_millisec, tTwo.utc_timestamp_millisec with 
+  else
+    match tOne.utc_timestamp_millisec, tTwo.utc_timestamp_millisec with
     | None      , None      -> true
     | Some _    , None      -> true
     | None      , Some _    -> false
@@ -304,7 +304,7 @@ let utctimestamp_GreaterThan_micro_micro ( tOne: fix_utctimestamp_micro) (tTwo :
   if utctimestamp_Equal_micro_micro tOne tTwo then false
   else
   if tOne.utc_timestamp_year          > tTwo.utc_timestamp_year   then true
-  else if tOne.utc_timestamp_year     < tTwo.utc_timestamp_year   then false 
+  else if tOne.utc_timestamp_year     < tTwo.utc_timestamp_year   then false
   else if tOne.utc_timestamp_month    > tTwo.utc_timestamp_month  then true
   else if tOne.utc_timestamp_month    < tTwo.utc_timestamp_month  then false
   else if tOne.utc_timestamp_day      > tTwo.utc_timestamp_day    then true
@@ -315,8 +315,8 @@ let utctimestamp_GreaterThan_micro_micro ( tOne: fix_utctimestamp_micro) (tTwo :
   else if tOne.utc_timestamp_minute   < tTwo.utc_timestamp_minute then false
   else if tOne.utc_timestamp_second   > tTwo.utc_timestamp_second then true
   else if tOne.utc_timestamp_second   < tTwo.utc_timestamp_second then false
-  else 
-    match tOne.utc_timestamp_microsec, tTwo.utc_timestamp_microsec with 
+  else
+    match tOne.utc_timestamp_microsec, tTwo.utc_timestamp_microsec with
     | None      , None      -> true
     | Some _    , None      -> true
     | None      , Some _    -> false
@@ -328,7 +328,7 @@ let utctimestamp_GreaterThan_milli_micro ( tOne: fix_utctimestamp_milli) (tTwo :
   if utctimestamp_Equal_milli_micro tOne tTwo then false
   else
   if tOne.utc_timestamp_year          > tTwo.utc_timestamp_year   then true
-  else if tOne.utc_timestamp_year     < tTwo.utc_timestamp_year   then false 
+  else if tOne.utc_timestamp_year     < tTwo.utc_timestamp_year   then false
   else if tOne.utc_timestamp_month    > tTwo.utc_timestamp_month  then true
   else if tOne.utc_timestamp_month    < tTwo.utc_timestamp_month  then false
   else if tOne.utc_timestamp_day      > tTwo.utc_timestamp_day    then true
@@ -339,8 +339,8 @@ let utctimestamp_GreaterThan_milli_micro ( tOne: fix_utctimestamp_milli) (tTwo :
   else if tOne.utc_timestamp_minute   < tTwo.utc_timestamp_minute then false
   else if tOne.utc_timestamp_second   > tTwo.utc_timestamp_second then true
   else if tOne.utc_timestamp_second   < tTwo.utc_timestamp_second then false
-  else 
-    match tOne.utc_timestamp_millisec, tTwo.utc_timestamp_microsec with 
+  else
+    match tOne.utc_timestamp_millisec, tTwo.utc_timestamp_microsec with
     | None      , None      -> true
     | Some _    , None      -> true
     | None      , Some _    -> false
@@ -352,7 +352,7 @@ let utctimestamp_GreaterThan_micro_milli ( tOne: fix_utctimestamp_micro) (tTwo :
   if utctimestamp_Equal_micro_milli tOne tTwo then false
   else
   if tOne.utc_timestamp_year          > tTwo.utc_timestamp_year   then true
-  else if tOne.utc_timestamp_year     < tTwo.utc_timestamp_year   then false 
+  else if tOne.utc_timestamp_year     < tTwo.utc_timestamp_year   then false
   else if tOne.utc_timestamp_month    > tTwo.utc_timestamp_month  then true
   else if tOne.utc_timestamp_month    < tTwo.utc_timestamp_month  then false
   else if tOne.utc_timestamp_day      > tTwo.utc_timestamp_day    then true
@@ -363,8 +363,8 @@ let utctimestamp_GreaterThan_micro_milli ( tOne: fix_utctimestamp_micro) (tTwo :
   else if tOne.utc_timestamp_minute   < tTwo.utc_timestamp_minute then false
   else if tOne.utc_timestamp_second   > tTwo.utc_timestamp_second then true
   else if tOne.utc_timestamp_second   < tTwo.utc_timestamp_second then false
-  else 
-    match tOne.utc_timestamp_microsec, tTwo.utc_timestamp_millisec with 
+  else
+    match tOne.utc_timestamp_microsec, tTwo.utc_timestamp_millisec with
     | None      , None      -> true
     | Some _    , None      -> true
     | None      , Some _    -> false
@@ -444,34 +444,34 @@ let make_localmktdate ( year:int) (month:int) (day : int) = {
 
 
 let is_valid_localmktdate ( lmd : fix_localmktdate ) =
-  0 <= lmd.localmktdate_year && lmd.localmktdate_year <= 9999 && 
-  1 <= lmd.localmktdate_month && lmd.localmktdate_month <= 12 && 
+  0 <= lmd.localmktdate_year && lmd.localmktdate_year <= 9999 &&
+  1 <= lmd.localmktdate_month && lmd.localmktdate_month <= 12 &&
   1 <= lmd.localmktdate_day && lmd.localmktdate_day <= 31
 ;;
 
-let localmktdate_GreaterThan ( lmdOne: fix_localmktdate) (lmdTwo : fix_localmktdate ) = 
+let localmktdate_GreaterThan ( lmdOne: fix_localmktdate) (lmdTwo : fix_localmktdate ) =
   if lmdOne.localmktdate_year > lmdTwo.localmktdate_year then true else
-  if lmdOne.localmktdate_year < lmdTwo.localmktdate_year then false else 
+  if lmdOne.localmktdate_year < lmdTwo.localmktdate_year then false else
   if lmdOne.localmktdate_month > lmdTwo.localmktdate_month then true else
   if lmdOne.localmktdate_month < lmdTwo.localmktdate_month then false else
     lmdOne.localmktdate_day > lmdTwo.localmktdate_day
 ;;
 
-let localmktdate_LessThan ( lmdOne: fix_localmktdate) (lmdTwo : fix_localmktdate ) = 
+let localmktdate_LessThan ( lmdOne: fix_localmktdate) (lmdTwo : fix_localmktdate ) =
   if lmdOne.localmktdate_year < lmdTwo.localmktdate_year then true else
-  if lmdOne.localmktdate_year > lmdTwo.localmktdate_year then false else 
+  if lmdOne.localmktdate_year > lmdTwo.localmktdate_year then false else
   if lmdOne.localmktdate_month < lmdTwo.localmktdate_month then true else
   if lmdOne.localmktdate_month > lmdTwo.localmktdate_month then false else
     lmdOne.localmktdate_day < lmdTwo.localmktdate_day
 ;;
 
-let localmktdate_Equal ( lmdOne :fix_localmktdate) (lmdTwo : fix_localmktdate  ) = 
+let localmktdate_Equal ( lmdOne :fix_localmktdate) (lmdTwo : fix_localmktdate  ) =
   lmdOne.localmktdate_year = lmdTwo.localmktdate_year &&
   lmdOne.localmktdate_month = lmdTwo.localmktdate_month &&
   lmdOne.localmktdate_day = lmdTwo.localmktdate_day
 ;;
 
-let localmktdate_GreaterThanEqual ( lmdOne: fix_localmktdate) (lmdTwo : fix_localmktdate  ) = 
+let localmktdate_GreaterThanEqual ( lmdOne: fix_localmktdate) (lmdTwo : fix_localmktdate  ) =
   localmktdate_GreaterThan lmdOne lmdTwo || localmktdate_Equal lmdOne lmdTwo
 ;;
 
@@ -480,7 +480,7 @@ let localmktdate_LessThanEqual ( lmdOne: fix_localmktdate) (lmdTwo :  fix_localm
 ;;
 
 (** Week *)
-type fix_week = 
+type fix_week =
   | Week_1
   | Week_2
   | Week_3
@@ -515,9 +515,9 @@ let make_monthyear ( year:int) (month:int) (week : fix_week option) = {
 
 
 let is_valid_monthyear ( my : fix_monthyear ) =
-  0 <= my.monthyear_year && my.monthyear_year <= 9999 && 
+  0 <= my.monthyear_year && my.monthyear_year <= 9999 &&
   0 <= my.monthyear_month && my.monthyear_month <= 12 && (
-    match my.monthyear_day with 
+    match my.monthyear_day with
     | None -> true
     | Some d -> 0 <= d && d <= 31
   ) && (
@@ -559,11 +559,11 @@ let monthyear_Equal ( myOne: fix_monthyear) (myTwo : fix_monthyear) =
   myOne.monthyear_day = myTwo.monthyear_day
 ;;
 
-let monthyear_GreaterThanEqual ( myOne : fix_monthyear) (myTwo : fix_monthyear ) = 
+let monthyear_GreaterThanEqual ( myOne : fix_monthyear) (myTwo : fix_monthyear ) =
   monthyear_GreaterThan myOne myTwo || monthyear_Equal  myOne myTwo
 ;;
 
-let monthyear_LessThanEqual ( myOne : fix_monthyear) (myTwo : fix_monthyear  ) = 
+let monthyear_LessThanEqual ( myOne : fix_monthyear) (myTwo : fix_monthyear  ) =
   monthyear_LessThan myOne myTwo || monthyear_Equal myOne myTwo
 ;;
 
@@ -599,7 +599,7 @@ let default_utctimeonly_micro = {
 
 let normalise_utctimeonly_milli ( ts : fix_utctimeonly_milli ) =
   let carry_secs  = calculate_carry ts.utc_timeonly_second 60 0 in
-  let new_minute  = if carry_secs.carry_over then ( ts.utc_timeonly_minute + 1)  else ts.utc_timeonly_minute in 
+  let new_minute  = if carry_secs.carry_over then ( ts.utc_timeonly_minute + 1)  else ts.utc_timeonly_minute in
   let carry_mins  = calculate_carry  new_minute            60 0  in
   let new_hour    = if carry_mins.carry_over then ( ts.utc_timeonly_hour + 1 )   else ts.utc_timeonly_hour
   in {
@@ -612,7 +612,7 @@ let normalise_utctimeonly_milli ( ts : fix_utctimeonly_milli ) =
 
 let normalise_utctimeonly_micro ( ts : fix_utctimeonly_micro ) =
   let carry_secs  = calculate_carry ts.utc_timeonly_second 60 0 in
-  let new_minute  = if carry_secs.carry_over then ( ts.utc_timeonly_minute + 1)  else ts.utc_timeonly_minute in 
+  let new_minute  = if carry_secs.carry_over then ( ts.utc_timeonly_minute + 1)  else ts.utc_timeonly_minute in
   let carry_mins  = calculate_carry  new_minute            60 0  in
   let new_hour    = if carry_mins.carry_over then ( ts.utc_timeonly_hour + 1 )   else ts.utc_timeonly_hour
   in {
@@ -623,7 +623,7 @@ let normalise_utctimeonly_micro ( ts : fix_utctimeonly_micro ) =
   }
 ;;
 
-let make_utctimeonly_milli (hour:int) (minute:int) (second:int) (millisec: int option) : fix_utctimeonly_milli = 
+let make_utctimeonly_milli (hour:int) (minute:int) (second:int) (millisec: int option) : fix_utctimeonly_milli =
   normalise_utctimeonly_milli {
     utc_timeonly_hour       = hour;
     utc_timeonly_minute     = minute;
@@ -631,7 +631,7 @@ let make_utctimeonly_milli (hour:int) (minute:int) (second:int) (millisec: int o
     utc_timeonly_millisec   = millisec;
   };;
 
-let make_utctimeonly_micro (hour:int) (minute:int) (second:int) (microsec: int option) : fix_utctimeonly_micro = 
+let make_utctimeonly_micro (hour:int) (minute:int) (second:int) (microsec: int option) : fix_utctimeonly_micro =
   normalise_utctimeonly_micro {
     utc_timeonly_hour       = hour;
     utc_timeonly_minute     = minute;
@@ -644,7 +644,7 @@ let convert_utctimeonly_milli_micro (f1:fix_utctimeonly_milli) : fix_utctimeonly
     utc_timeonly_hour      = f1.utc_timeonly_hour;
     utc_timeonly_minute    = f1.utc_timeonly_minute;
     utc_timeonly_second    = f1.utc_timeonly_second;
-    utc_timeonly_microsec  = f1.utc_timeonly_millisec;
+    utc_timeonly_microsec  = Option.map (fun x -> x * 1000) f1.utc_timeonly_millisec;
   }
 ;;
 
@@ -653,31 +653,31 @@ let convert_utctimeonly_micro_milli (f1:fix_utctimeonly_micro) : fix_utctimeonly
     utc_timeonly_hour      = f1.utc_timeonly_hour;
     utc_timeonly_minute    = f1.utc_timeonly_minute;
     utc_timeonly_second    = f1.utc_timeonly_second;
-    utc_timeonly_millisec  = f1.utc_timeonly_microsec;
+    utc_timeonly_millisec  = Option.map (fun x -> x / 1000) f1.utc_timeonly_microsec;
   }
 ;;
 
 let is_valid_utctimeonly_milli ( t : fix_utctimeonly_milli ) =
-  0 <= t.utc_timeonly_hour && 
+  0 <= t.utc_timeonly_hour &&
   t.utc_timeonly_hour <= 23 &&
   0 <= t.utc_timeonly_minute &&
   t.utc_timeonly_minute <= 59 &&
   0 <= t.utc_timeonly_second &&
-  t.utc_timeonly_second <= 59 && ( 
-    match t.utc_timeonly_millisec with 
+  t.utc_timeonly_second <= 59 && (
+    match t.utc_timeonly_millisec with
     | None      -> true
     | Some ms   -> 0 <= ms && ms <= 999
   )
 ;;
 
 let is_valid_utctimeonly_micro ( t : fix_utctimeonly_micro ) =
-  0 <= t.utc_timeonly_hour && 
+  0 <= t.utc_timeonly_hour &&
   t.utc_timeonly_hour <= 23 &&
   0 <= t.utc_timeonly_minute &&
   t.utc_timeonly_minute <= 59 &&
   0 <= t.utc_timeonly_second &&
-  t.utc_timeonly_second <= 59 && ( 
-    match t.utc_timeonly_microsec with 
+  t.utc_timeonly_second <= 59 && (
+    match t.utc_timeonly_microsec with
     | None      -> true
     | Some ms   -> 0 <= ms && ms <= 999999
   )
@@ -698,7 +698,7 @@ let utctimeonly_Equal_milli_micro ( tOne: fix_utctimeonly_milli) (tTwo : fix_utc
       utc_timeonly_second    = tTwo.utc_timeonly_second;
       utc_timeonly_millisec = match tTwo.utc_timeonly_microsec with
         | None -> None
-        | Some x -> Some (x/1000)}) 
+        | Some x -> Some (x/1000)})
 ;;
 
 let utctimeonly_Equal_micro_milli ( tOne: fix_utctimeonly_micro) (tTwo : fix_utctimeonly_milli  ) =
@@ -712,14 +712,14 @@ let utctimeonly_Equal_micro_milli ( tOne: fix_utctimeonly_micro) (tTwo : fix_utc
 ;;
 
 let utctimeonly_GreaterThan_milli_milli ( tOne:fix_utctimeonly_milli) (tTwo : fix_utctimeonly_milli ) =
-  if utctimeonly_Equal_milli_milli tOne tTwo then false 
+  if utctimeonly_Equal_milli_milli tOne tTwo then false
   else if tOne.utc_timeonly_hour > tTwo.utc_timeonly_hour then true
   else if tOne.utc_timeonly_hour < tTwo.utc_timeonly_hour then false
   else if tOne.utc_timeonly_minute > tTwo.utc_timeonly_minute then true
   else if tOne.utc_timeonly_minute < tTwo.utc_timeonly_minute then false
   else if tOne.utc_timeonly_second > tTwo.utc_timeonly_second then true
-  else 
-    match tOne.utc_timeonly_millisec, tTwo.utc_timeonly_millisec with 
+  else
+    match tOne.utc_timeonly_millisec, tTwo.utc_timeonly_millisec with
     | None      , None      -> true
     | Some _    , None      -> true
     | None      , Some _    -> false
@@ -727,14 +727,14 @@ let utctimeonly_GreaterThan_milli_milli ( tOne:fix_utctimeonly_milli) (tTwo : fi
 ;;
 
 let utctimeonly_GreaterThan_micro_micro ( tOne:fix_utctimeonly_micro) (tTwo : fix_utctimeonly_micro ) =
-  if utctimeonly_Equal_micro_micro tOne tTwo then false 
+  if utctimeonly_Equal_micro_micro tOne tTwo then false
   else if tOne.utc_timeonly_hour > tTwo.utc_timeonly_hour then true
   else if tOne.utc_timeonly_hour < tTwo.utc_timeonly_hour then false
   else if tOne.utc_timeonly_minute > tTwo.utc_timeonly_minute then true
   else if tOne.utc_timeonly_minute < tTwo.utc_timeonly_minute then false
   else if tOne.utc_timeonly_second > tTwo.utc_timeonly_second then true
-  else 
-    match tOne.utc_timeonly_microsec, tTwo.utc_timeonly_microsec with 
+  else
+    match tOne.utc_timeonly_microsec, tTwo.utc_timeonly_microsec with
     | None      , None      -> true
     | Some _    , None      -> true
     | None      , Some _    -> false
@@ -742,14 +742,14 @@ let utctimeonly_GreaterThan_micro_micro ( tOne:fix_utctimeonly_micro) (tTwo : fi
 ;;
 
 let utctimeonly_GreaterThan_milli_micro ( tOne:fix_utctimeonly_milli) (tTwo : fix_utctimeonly_micro ) =
-  if utctimeonly_Equal_milli_micro tOne tTwo then false 
+  if utctimeonly_Equal_milli_micro tOne tTwo then false
   else if tOne.utc_timeonly_hour > tTwo.utc_timeonly_hour then true
   else if tOne.utc_timeonly_hour < tTwo.utc_timeonly_hour then false
   else if tOne.utc_timeonly_minute > tTwo.utc_timeonly_minute then true
   else if tOne.utc_timeonly_minute < tTwo.utc_timeonly_minute then false
   else if tOne.utc_timeonly_second > tTwo.utc_timeonly_second then true
-  else 
-    match tOne.utc_timeonly_millisec, tTwo.utc_timeonly_microsec with 
+  else
+    match tOne.utc_timeonly_millisec, tTwo.utc_timeonly_microsec with
     | None      , None      -> true
     | Some _    , None      -> true
     | None      , Some _    -> false
@@ -757,14 +757,14 @@ let utctimeonly_GreaterThan_milli_micro ( tOne:fix_utctimeonly_milli) (tTwo : fi
 ;;
 
 let utctimeonly_GreaterThan_micro_milli ( tOne:fix_utctimeonly_micro) (tTwo : fix_utctimeonly_milli ) =
-  if utctimeonly_Equal_micro_milli tOne tTwo then false 
+  if utctimeonly_Equal_micro_milli tOne tTwo then false
   else if tOne.utc_timeonly_hour > tTwo.utc_timeonly_hour then true
   else if tOne.utc_timeonly_hour < tTwo.utc_timeonly_hour then false
   else if tOne.utc_timeonly_minute > tTwo.utc_timeonly_minute then true
   else if tOne.utc_timeonly_minute < tTwo.utc_timeonly_minute then false
   else if tOne.utc_timeonly_second > tTwo.utc_timeonly_second then true
-  else 
-    match tOne.utc_timeonly_microsec, tTwo.utc_timeonly_millisec with 
+  else
+    match tOne.utc_timeonly_microsec, tTwo.utc_timeonly_millisec with
     | None      , None      -> true
     | Some _    , None      -> true
     | None      , Some _    -> false
@@ -803,19 +803,19 @@ let utctimeonly_LessThanEqual_micro_milli ( tOne:fix_utctimeonly_micro) (tTwo : 
   not ( utctimeonly_GreaterThan_micro_milli tOne tTwo )
 ;;
 
-let utctimeonly_GreaterThanEqual_milli_milli ( tOne:fix_utctimeonly_milli) (tTwo : fix_utctimeonly_milli ) = 
+let utctimeonly_GreaterThanEqual_milli_milli ( tOne:fix_utctimeonly_milli) (tTwo : fix_utctimeonly_milli ) =
   utctimeonly_GreaterThan_milli_milli tOne tTwo || utctimeonly_Equal_milli_milli tOne tTwo
 ;;
 
-let utctimeonly_GreaterThanEqual_micro_micro ( tOne:fix_utctimeonly_micro) (tTwo : fix_utctimeonly_micro ) = 
+let utctimeonly_GreaterThanEqual_micro_micro ( tOne:fix_utctimeonly_micro) (tTwo : fix_utctimeonly_micro ) =
   utctimeonly_GreaterThan_micro_micro tOne tTwo || utctimeonly_Equal_micro_micro tOne tTwo
 ;;
 
-let utctimeonly_GreaterThanEqual_milli_micro ( tOne:fix_utctimeonly_milli) (tTwo : fix_utctimeonly_micro ) = 
+let utctimeonly_GreaterThanEqual_milli_micro ( tOne:fix_utctimeonly_milli) (tTwo : fix_utctimeonly_micro ) =
   utctimeonly_GreaterThan_milli_micro tOne tTwo || utctimeonly_Equal_milli_micro tOne tTwo
 ;;
 
-let utctimeonly_GreaterThanEqual_micro_milli ( tOne:fix_utctimeonly_micro) (tTwo : fix_utctimeonly_milli ) = 
+let utctimeonly_GreaterThanEqual_micro_milli ( tOne:fix_utctimeonly_micro) (tTwo : fix_utctimeonly_milli ) =
   utctimeonly_GreaterThan_micro_milli tOne tTwo || utctimeonly_Equal_micro_milli tOne tTwo
 ;;
 
@@ -841,13 +841,13 @@ let make_utcdateonly ( year:int) (month:int) (day : int) = {
 };;
 
 let is_valid_utcdateonly ( d : fix_utcdateonly ) =
-  0 <= d.utc_dateonly_year && d.utc_dateonly_year <= 9999 && 
-  1 <= d.utc_dateonly_month && d.utc_dateonly_month <= 12 && 
+  0 <= d.utc_dateonly_year && d.utc_dateonly_year <= 9999 &&
+  1 <= d.utc_dateonly_month && d.utc_dateonly_month <= 12 &&
   1 <= d.utc_dateonly_day && d.utc_dateonly_day <= 31
 ;;
 
 let utcdateonly_GreaterThan ( dOne:fix_utcdateonly) (dTwo : fix_utcdateonly ) =
-  if dOne.utc_dateonly_year > dTwo.utc_dateonly_year then true else 
+  if dOne.utc_dateonly_year > dTwo.utc_dateonly_year then true else
   if dOne.utc_dateonly_year < dTwo.utc_dateonly_year then false else
   if dOne.utc_dateonly_month > dTwo.utc_dateonly_month then true else
   if dOne.utc_dateonly_month < dTwo.utc_dateonly_month then false else
@@ -855,7 +855,7 @@ let utcdateonly_GreaterThan ( dOne:fix_utcdateonly) (dTwo : fix_utcdateonly ) =
 ;;
 
 let utcdateonly_LessThan ( dOne:fix_utcdateonly) (dTwo : fix_utcdateonly  ) =
-  if dOne.utc_dateonly_year > dTwo.utc_dateonly_year then false else 
+  if dOne.utc_dateonly_year > dTwo.utc_dateonly_year then false else
   if dOne.utc_dateonly_year < dTwo.utc_dateonly_year then true else
   if dOne.utc_dateonly_month > dTwo.utc_dateonly_month then false else
   if dOne.utc_dateonly_month < dTwo.utc_dateonly_month then true else
@@ -890,9 +890,9 @@ type fix_duration = {
 
 let is_valid_duration ( dur : fix_duration ) =
   let y =  dur.dur_years in
-  0 <= y && y <= 100 &&    
-  let m = dur.dur_months in 
-  0 <= m && m <= 12 &&   
+  0 <= y && y <= 100 &&
+  let m = dur.dur_months in
+  0 <= m && m <= 12 &&
   let d =  dur.dur_days in
   0 <= d && d <= 31 &&
   let h = dur.dur_hours in
@@ -904,16 +904,16 @@ let is_valid_duration ( dur : fix_duration ) =
 ;;
 
 
-let normalise_duration (d:fix_duration):fix_duration = 
+let normalise_duration (d:fix_duration):fix_duration =
   let carry_secs  = calculate_carry d.dur_seconds 60 0 in
-  let new_minute  = if carry_secs.carry_over then ( d.dur_minutes + 1)  else d.dur_minutes in 
+  let new_minute  = if carry_secs.carry_over then ( d.dur_minutes + 1)  else d.dur_minutes in
   let carry_mins  = calculate_carry  new_minute            60 0  in
-  let new_hour    = if carry_mins.carry_over then ( d.dur_hours + 1 )   else d.dur_hours in 
-  let carry_hours = calculate_carry  new_hour               24 0 in 
-  let new_days    = if carry_hours.carry_over then ( d.dur_days + 1 )   else d.dur_days in 
+  let new_hour    = if carry_mins.carry_over then ( d.dur_hours + 1 )   else d.dur_hours in
+  let carry_hours = calculate_carry  new_hour               24 0 in
+  let new_days    = if carry_hours.carry_over then ( d.dur_days + 1 )   else d.dur_days in
   let carry_days  = calculate_carry new_days (1 + (how_many_days d.dur_months d.dur_years )) 1 in
   let new_months  = if carry_days.carry_over then ( d.dur_months + 1 )  else d.dur_months in
-  let carry_months = calculate_carry new_months            13 1 in 
+  let carry_months = calculate_carry new_months            13 1 in
   let new_years   = if carry_months.carry_over then ( d.dur_years + 1 ) else d.dur_years in {
     dur_seconds    = carry_secs.new_field;
     dur_minutes    = carry_mins.new_field;
@@ -925,7 +925,7 @@ let normalise_duration (d:fix_duration):fix_duration =
 ;;
 
 
-let make_duration years months days hours minutes seconds = 
+let make_duration years months days hours minutes seconds =
   normalise_duration
     {
       dur_years               = years;
@@ -937,15 +937,15 @@ let make_duration years months days hours minutes seconds =
     }
 ;;
 
-let utctimestamp_milli_duration_Add ( t:fix_utctimestamp_milli) (dur : fix_duration ) = 
+let utctimestamp_milli_duration_Add ( t:fix_utctimestamp_milli) (dur : fix_duration ) =
   let new_seconds = t.utc_timestamp_second + dur.dur_seconds in
   let new_minute = t.utc_timestamp_minute + dur.dur_minutes in
-  let new_hour = t.utc_timestamp_hour + dur.dur_hours in 
+  let new_hour = t.utc_timestamp_hour + dur.dur_hours in
   let new_day = t.utc_timestamp_day + dur.dur_days in
   let new_month = t.utc_timestamp_month + dur.dur_months in
   let new_year = t.utc_timestamp_year + dur.dur_years in
   let new_ts = {
-    utc_timestamp_millisec  = t.utc_timestamp_millisec; 
+    utc_timestamp_millisec  = t.utc_timestamp_millisec;
     utc_timestamp_second    = new_seconds;
     utc_timestamp_minute    = new_minute;
     utc_timestamp_hour      = new_hour;
@@ -956,19 +956,19 @@ let utctimestamp_milli_duration_Add ( t:fix_utctimestamp_milli) (dur : fix_durat
   normalise_utctimestamp_milli ( new_ts )
 ;;
 
-let duration_utctimestamp_milli_Add (dur : fix_duration) ( t:fix_utctimestamp_milli) = 
+let duration_utctimestamp_milli_Add (dur : fix_duration) ( t:fix_utctimestamp_milli) =
   utctimestamp_milli_duration_Add t dur
 ;;
 
-let utctimestamp_micro_duration_Add ( t:fix_utctimestamp_micro) (dur : fix_duration ) = 
+let utctimestamp_micro_duration_Add ( t:fix_utctimestamp_micro) (dur : fix_duration ) =
   let new_seconds = t.utc_timestamp_second + dur.dur_seconds in
   let new_minute = t.utc_timestamp_minute + dur.dur_minutes in
-  let new_hour = t.utc_timestamp_hour + dur.dur_hours in 
+  let new_hour = t.utc_timestamp_hour + dur.dur_hours in
   let new_day = t.utc_timestamp_day + dur.dur_days in
   let new_month = t.utc_timestamp_month + dur.dur_months in
   let new_year = t.utc_timestamp_year + dur.dur_years in
   let new_ts = {
-    utc_timestamp_microsec  = t.utc_timestamp_microsec; 
+    utc_timestamp_microsec  = t.utc_timestamp_microsec;
     utc_timestamp_second    = new_seconds;
     utc_timestamp_minute    = new_minute;
     utc_timestamp_hour      = new_hour;
@@ -979,11 +979,11 @@ let utctimestamp_micro_duration_Add ( t:fix_utctimestamp_micro) (dur : fix_durat
   normalise_utctimestamp_micro ( new_ts )
 ;;
 
-let duration_utctimestamp_micro_Add (dur : fix_duration) ( t:fix_utctimestamp_micro) = 
+let duration_utctimestamp_micro_Add (dur : fix_duration) ( t:fix_utctimestamp_micro) =
   utctimestamp_micro_duration_Add t dur
 ;;
 
-let seconds_to_duration ( seconds ) = 
+let seconds_to_duration ( seconds ) =
   normalise_duration {
     dur_years    = 0;
     dur_months   = 0;
@@ -1001,15 +1001,15 @@ let duration_to_seconds ( dur ) =
   let sec = sec + dur.dur_hours * 60 * 60 in
   let sec = sec + dur.dur_days * 24 * 60 * 60 in
   let sec = sec + dur.dur_months * 31 * 24 * 60 * 60 in
-  let sec = sec + dur.dur_years * 365 * 31 * 24 * 60 * 60 in    
+  let sec = sec + dur.dur_years * 365 * 31 * 24 * 60 * 60 in
   sec
 ;;
 
-let duration_Equal dur1 dur2 = 
+let duration_Equal dur1 dur2 =
   dur1 = dur2
 ;;
 
-let duration_GreaterThan dur1 dur2 = 
+let duration_GreaterThan dur1 dur2 =
   dur1.dur_years > dur2.dur_years ||
   (dur1.dur_years = dur2.dur_years &&
    dur1.dur_months > dur2.dur_months ||
@@ -1023,19 +1023,19 @@ let duration_GreaterThan dur1 dur2 =
        dur1.dur_seconds > dur2.dur_seconds)))))
 ;;
 
-let duration_GreaterThanEqual dur1 dur2 = 
+let duration_GreaterThanEqual dur1 dur2 =
   duration_GreaterThan dur1 dur2 || duration_Equal dur1 dur2
 ;;
 
-let duration_LessThan dur1 dur2 = 
+let duration_LessThan dur1 dur2 =
   not (duration_GreaterThanEqual dur1 dur2)
 ;;
 
-let duration_LessThanEqual dur1 dur2 = 
+let duration_LessThanEqual dur1 dur2 =
   not (duration_GreaterThan dur1 dur2)
 ;;
 
-let convert_utctimestamp_milli_utctimeonly_milli (ts:fix_utctimestamp_milli) : (fix_utctimeonly_milli) = 
+let convert_utctimestamp_milli_utctimeonly_milli (ts:fix_utctimestamp_milli) : (fix_utctimeonly_milli) =
   {
     utc_timeonly_hour     = ts.utc_timestamp_hour;
     utc_timeonly_minute    = ts.utc_timestamp_minute;
@@ -1044,7 +1044,7 @@ let convert_utctimestamp_milli_utctimeonly_milli (ts:fix_utctimestamp_milli) : (
   }
 ;;
 
-let convert_utctimestamp_micro_utctimeonly_micro (ts:fix_utctimestamp_micro) : (fix_utctimeonly_micro) = 
+let convert_utctimestamp_micro_utctimeonly_micro (ts:fix_utctimestamp_micro) : (fix_utctimeonly_micro) =
   {
     utc_timeonly_hour     = ts.utc_timestamp_hour;
     utc_timeonly_minute    = ts.utc_timestamp_minute;
@@ -1053,7 +1053,7 @@ let convert_utctimestamp_micro_utctimeonly_micro (ts:fix_utctimestamp_micro) : (
   }
 ;;
 
-let convert_utctimestamp_milli_utctimeonly_micro (ts:fix_utctimestamp_milli) : (fix_utctimeonly_micro) = 
+let convert_utctimestamp_milli_utctimeonly_micro (ts:fix_utctimestamp_milli) : (fix_utctimeonly_micro) =
   {
     utc_timeonly_hour     = ts.utc_timestamp_hour;
     utc_timeonly_minute    = ts.utc_timestamp_minute;
@@ -1064,7 +1064,7 @@ let convert_utctimestamp_milli_utctimeonly_micro (ts:fix_utctimestamp_milli) : (
   }
 ;;
 
-let convert_utctimestamp_micro_utctimeonly_milli (ts:fix_utctimestamp_micro) : (fix_utctimeonly_milli) = 
+let convert_utctimestamp_micro_utctimeonly_milli (ts:fix_utctimestamp_micro) : (fix_utctimeonly_milli) =
   {
     utc_timeonly_hour     = ts.utc_timestamp_hour;
     utc_timeonly_minute    = ts.utc_timestamp_minute;
@@ -1113,12 +1113,12 @@ let convert_utctimestamp_milli_monthyear (ts:fix_utctimestamp_milli) : (fix_mont
   monthyear_week  = None;
 };;
 
-let make_utctimestamp_micro_utctimeonly_micro_utcdateonly 
-    (to_:fix_utctimeonly_micro) 
-    (do_:fix_utcdateonly) 
-  : (fix_utctimestamp_micro) = 
+let make_utctimestamp_micro_utctimeonly_micro_utcdateonly
+    (to_:fix_utctimeonly_micro)
+    (do_:fix_utcdateonly)
+  : (fix_utctimestamp_micro) =
   {
-    utc_timestamp_microsec  = to_.utc_timeonly_microsec; 
+    utc_timestamp_microsec  = to_.utc_timeonly_microsec;
     utc_timestamp_second    = to_.utc_timeonly_second;
     utc_timestamp_minute    = to_.utc_timeonly_minute;
     utc_timestamp_hour      = to_.utc_timeonly_hour;
@@ -1127,12 +1127,12 @@ let make_utctimestamp_micro_utctimeonly_micro_utcdateonly
     utc_timestamp_year      = do_.utc_dateonly_year
   };;
 
-let make_utctimestamp_milli_utctimeonly_milli_utcdateonly 
-    (to_:fix_utctimeonly_milli) 
-    (do_:fix_utcdateonly) 
-  : (fix_utctimestamp_milli) = 
+let make_utctimestamp_milli_utctimeonly_milli_utcdateonly
+    (to_:fix_utctimeonly_milli)
+    (do_:fix_utcdateonly)
+  : (fix_utctimestamp_milli) =
   {
-    utc_timestamp_millisec  = to_.utc_timeonly_millisec; 
+    utc_timestamp_millisec  = to_.utc_timeonly_millisec;
     utc_timestamp_second    = to_.utc_timeonly_second;
     utc_timestamp_minute    = to_.utc_timeonly_minute;
     utc_timestamp_hour      = to_.utc_timeonly_hour;
@@ -1141,10 +1141,10 @@ let make_utctimestamp_milli_utctimeonly_milli_utcdateonly
     utc_timestamp_year      = do_.utc_dateonly_year
   };;
 
-let make_utctimestamp_micro_utctimeonly_milli_utcdateonly 
-    (to_:fix_utctimeonly_milli) 
-    (do_:fix_utcdateonly) 
-  : (fix_utctimestamp_micro) = 
+let make_utctimestamp_micro_utctimeonly_milli_utcdateonly
+    (to_:fix_utctimeonly_milli)
+    (do_:fix_utcdateonly)
+  : (fix_utctimestamp_micro) =
   {
     utc_timestamp_microsec  = (match to_.utc_timeonly_millisec with
         | None -> None
@@ -1157,10 +1157,10 @@ let make_utctimestamp_micro_utctimeonly_milli_utcdateonly
     utc_timestamp_year      = do_.utc_dateonly_year
   };;
 
-let make_utctimestamp_milli_utctimeonly_micro_utcdateonly 
-  (to_:fix_utctimeonly_micro) 
-  (do_:fix_utcdateonly) 
-: (fix_utctimestamp_milli) = 
+let make_utctimestamp_milli_utctimeonly_micro_utcdateonly
+  (to_:fix_utctimeonly_micro)
+  (do_:fix_utcdateonly)
+: (fix_utctimestamp_milli) =
 {
   utc_timestamp_millisec  = (match to_.utc_timeonly_microsec with
       | None -> None

--- a/src-protocol-pp/fix_engine_json.iml
+++ b/src-protocol-pp/fix_engine_json.iml
@@ -11,6 +11,7 @@
 [@@@import "../src-core-pp/datetime_json.iml"]
 [@@@import "../src-core-pp/base_types_json.iml"]
 [@@@import "../src-protocol-exts-pp/full_app_messages_json.iml"]
+[@@@import "../src-protocol-exts-pp/full_admin_messages_json.iml"]
 [@@@import "full_messages_json.iml"]
 [@@@import "../src-core-time-defaults-pp/time_defaults_json.iml"]
 [@@@program]
@@ -19,6 +20,7 @@ open Fix_engine_state
 open Datetime_json
 open Base_types_json
 open Full_app_messages_json
+open Full_admin_messages_json
 open Full_messages_json
 open Time_defaults_json
 
@@ -40,6 +42,9 @@ let fix_engine_mode_to_string = function
 let manual_int_data_to_json x : json = match x with  
     | ResetSession    -> `String "ResetSession" 
     | IncrementOutSeq -> `String "IncrementOutSeq"
+    | SendBusinessReject data -> `Assoc 
+      [ ( "IncrementOutSeq" , full_msg_business_reject_to_json data ) ]
+
 
 
 (** These are the messages going in/out of the engine to the owner. *)

--- a/src-simulation-utils/engine.iml
+++ b/src-simulation-utils/engine.iml
@@ -2,7 +2,7 @@
 module Internal : sig 
   type t
   type event =
-    | Internal   of Fix_engine_state.fix_engine_int_out_msg
+    | OutFIXData of ( int * Full_app_messages.full_app_msg_data )
     | FIXMessage of Full_messages.full_top_level_msg
     | State      of Fix_engine_state.fix_engine_state
 
@@ -29,7 +29,7 @@ end = struct
     | GetState      
 
   type event =
-    | Internal   of Fix_engine_state.fix_engine_int_out_msg
+    | OutFIXData of ( int * Full_app_messages.full_app_msg_data )
     | FIXMessage of Full_messages.full_top_level_msg
     | State      of Fix_engine_state.fix_engine_state
 
@@ -39,14 +39,19 @@ end = struct
     ; timer         : float
     }
 
+  let extract_out_fix_data engine_state msg =
+    let open Fix_engine_state in
+    OutFIXData ( engine_state.incoming_seq_num , msg )
+
   (** Calls Fix_engine.one_step and pubs outgoing messages while busy *)  
   let rec while_busy_loop t engine_state  =
     let engine_state = Fix_engine.one_step engine_state in
     (* This assumes that after one_step we can get either ontgoing internal or outgoing FIX message *)
     begin match ( engine_state.outgoing_fix_msg , engine_state.outgoing_int_msg) with
       | Some msg, None -> t.recv ( FIXMessage msg )  
-      | None, Some msg -> t.recv ( Internal   msg ) 
-      | None, None     -> Lwt.return_unit
+      | None, Some (OutIntMsg_ApplicationData msg) -> t.recv ( extract_out_fix_data engine_state msg ) 
+      | None, Some _ 
+      | None, None   -> Lwt.return_unit
       |  _ -> Lwt.fail_with "Critical internal error in fix_engine model" 
     end >>= fun () ->
     let engine_state = { engine_state with outgoing_fix_msg = None ; outgoing_int_msg = None } in

--- a/src-simulation/server.ml
+++ b/src-simulation/server.ml
@@ -39,8 +39,8 @@ let rec loop t =
       >>= function
       | Engine.FIXMessage (Full_messages.ValidMsg msg) ->
           engine_to_fixio t.fixio msg
-      | Engine.Internal msg ->
-          Model.send_fix t.model msg
+      | Engine.OutFIXData (_,msg) ->
+          Model.send_fix t.model (OutIntMsg_ApplicationData msg)
       | Engine.State state ->
           save_state_seqns t.sessn state
       | _ ->

--- a/src-simulation/test_server.ml
+++ b/src-simulation/test_server.ml
@@ -23,8 +23,8 @@ let rec loop (fixio_box, fixio) (engine_box, engine) (model_box, model) =
       >>= function
       | Engine.FIXMessage (Full_messages.ValidMsg msg) ->
           engine_to_fixio fixio msg
-      | Engine.Internal msg ->
-          Model.send_fix model msg
+      | Engine.OutFIXData (_,msg) ->
+          Model.send_fix model (OutIntMsg_ApplicationData msg) 
       | _ ->
           Lwt.return_unit )
     ; (Lwt_mvar.take fixio_box >>= fun msg -> fixio_to_engine engine msg)

--- a/src/fix_engine.iml
+++ b/src/fix_engine.iml
@@ -127,6 +127,17 @@ let proc_incoming_int_msg ( x, engine : fix_engine_int_inc_msg * fix_engine_stat
         let engine = { engine with incoming_int_msg = None } in
         match mi with 
         | ResetSession -> { engine with outgoing_int_msg = Some OutIntMsg_Reject }
+        | SendBusinessReject reject_data -> begin
+          let msg_data = Full_FIX_Admin_Msg ( Full_Msg_Business_Reject reject_data ) in
+          let msg = create_outbound_fix_msg ( engine, msg_data, false) in
+          { engine with 
+            fe_last_time_data_sent  = engine.fe_curr_time;
+            outgoing_fix_msg        = Some (ValidMsg ( msg )); 
+            incoming_int_msg        = None;
+            outgoing_seq_num        = engine.outgoing_seq_num + 1;
+            fe_history              = add_msg_to_history ( engine.fe_history, msg );
+          }         
+        end
         | IncrementOutSeq -> begin
             (** This intervention is used when we want to send a custom-made message on wire
             The outgoing seq number is increased - we also record this as a gap in history*)

--- a/src/fix_engine_state.iml
+++ b/src/fix_engine_state.iml
@@ -15,6 +15,7 @@
 [@@@import "../src-core-time-defaults/time_defaults.iml"]
 open Datetime;;
 open Full_admin_enums;;
+open Full_admin_messages;;
 open Full_app_messages;;
 open Full_messages;;
 open Time_defaults;;
@@ -23,6 +24,7 @@ open Time_defaults;;
 type manual_int_data = 
     | ResetSession
     | IncrementOutSeq
+    | SendBusinessReject of full_msg_business_reject_data
 ;;
 
 (** Request to initiate a new session. *)


### PR DESCRIPTION
-- some try/catch mechanisms in the Scanf functions to catch garbles floats and datetimes - picked up by parser combinators
-- addition of a stub monad for decoding from the runner AST to true ipl types - to be used in conjunction with ipl generation (in progress)
-- generalised AST, pretty printer, json encoder and decoder for the runner AST