### PR TITLE
bump: shuffle vendor/data_only_dirs

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,3 @@
+(subdir
+ vendor/imandra-ptime
+ (data_only_dirs vendor))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.2)
+(lang dune 2.5)
 (name fix-engine)
 
 (dialect

--- a/vendor/dune
+++ b/vendor/dune
@@ -1,1 +1,0 @@
-(vendored_dirs imandra-prelude imandra-ptime)


### PR DESCRIPTION
Fixes run-model-vgs make task when used in SIGMAX, by allowing support for recursive submodule clone (which SIGMAX needs).