### PR TITLE
OCX reflect `onBehalfOf`

### DIFF
--- a/fix-engine/src-runtime/config.ml
+++ b/fix-engine/src-runtime/config.ml
@@ -68,6 +68,9 @@ module Decode (D : Decoders.Decode.S) = struct
     let* target_id = field_def "target_id" def_target D.string in
     let* host_id = D.field_opt "host_id" D.string in
     let* on_behalf_id = D.field_opt "on_behalf_id" D.string in
+    let* reflect_on_behalf_of =
+      field_def "reflect_on_behalf_of" false D.bool
+    in
     let* begin_string = field_def "begin_string" "FIX.4.2" D.string in
     let* timer = field_def "timer" 1.0 D.float in
     let* strict_time_precision =
@@ -85,6 +88,7 @@ module Decode (D : Decoders.Decode.S) = struct
           target_id;
           host_id;
           on_behalf_id;
+          reflect_on_behalf_of;
           timer;
           strict_time_precision;
           precision;

--- a/fix-engine/src-runtime/engine.ml
+++ b/fix-engine/src-runtime/engine.ml
@@ -105,6 +105,7 @@ module Internal : sig
     target_id: string;
     host_id: string option;
     on_behalf_id: string option;
+    reflect_on_behalf_of: bool;
     logon_fields: (string * string) list;
     next_expected_msg_seq_num: bool;
     timer: float;
@@ -180,6 +181,7 @@ end = struct
     target_id: string;
     host_id: string option;
     on_behalf_id: string option;
+    reflect_on_behalf_of: bool;
     logon_fields: (string * string) list;
     next_expected_msg_seq_num: bool;
     timer: float;
@@ -379,6 +381,7 @@ end = struct
       fe_comp_id = config.comp_id;
       fe_sender_location_id = config.host_id;
       fe_on_behalf_of_comp_id = config.on_behalf_id;
+      fe_reflect_on_behalf_of = config.reflect_on_behalf_of;
       fe_target_comp_id = config.target_id;
       fe_curr_time = Current_time.get_current_utctimestamp_pico ();
       fe_max_num_logons_sent = Z.of_int 10;

--- a/fix-engine/src/fix_engine_state.iml
+++ b/fix-engine/src/fix_engine_state.iml
@@ -129,6 +129,10 @@ type fix_engine_state = {
   fe_sender_location_id: string option;  (** Location id string *)
   fe_on_behalf_of_comp_id: string option;  (** On behalf of string *)
   fe_deliver_to_comp_id: string option;  (** Deliver to string *)
+  fe_reflect_on_behalf_of: bool;
+      (** If true, reflect an inbound application message's OnBehalfOfCompID (115)
+          back as DeliverToCompID (128) on our responses (standard on-behalf-of
+          routing reversal). Off by default. *)
   incoming_int_msg: fix_engine_int_inc_msg option;
       (** Incoming internal messages (application). *)
   outgoing_int_msg: fix_engine_int_out_msg option;
@@ -188,6 +192,7 @@ let init_fix_engine_state =
     fe_sender_location_id = None;
     fe_on_behalf_of_comp_id = None;
     fe_deliver_to_comp_id = None;
+    fe_reflect_on_behalf_of = false;
     incoming_int_msg = None;
     outgoing_int_msg = None;
     incoming_seq_num = 0;

--- a/fix-engine/src/fix_engine_transitions.iml
+++ b/fix-engine/src/fix_engine_transitions.iml
@@ -331,11 +331,23 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
         if engine.fe_application_up then
             let out_int = match m.full_msg_header.h_poss_resend with
             | Some true -> OutIntMsg_ResendApplicationData app_msg
-            |         _ -> OutIntMsg_ApplicationData app_msg  in {
+            |         _ -> OutIntMsg_ApplicationData app_msg  in
+            (* When configured, reflect the counterparty's OnBehalfOfCompID (115)
+               back as DeliverToCompID (128) on our responses (standard on-behalf-of
+               routing reversal). Captured per inbound message, so it is correct even
+               if 115 varies between orders, or is absent (then no 128 is emitted).
+               When disabled, fe_deliver_to_comp_id is left unchanged. *)
+            let fe_deliver_to_comp_id =
+                if engine.fe_reflect_on_behalf_of then
+                    m.full_msg_header.h_on_behalf_of_comp_id
+                else
+                    engine.fe_deliver_to_comp_id
+            in {
             engine with
                 incoming_seq_num = m.full_msg_header.h_msg_seq_num;
                 outgoing_int_msg = Some out_int;
                 incoming_fix_msg = None;
+                fe_deliver_to_comp_id;
         } else
             begin
                 let biz_reject_data = {


### PR DESCRIPTION
Engine-side of #231: when the new per-session `reflect_on_behalf_of` flag is set, reflect an inbound application message's `OnBehalfOfCompID` (115) into our response's `DeliverToCompID` (128) — the standard on-behalf-of routing reversal. Captured per inbound message; forward-only (a configured `on_behalf_id` is never clobbered); off by default.

Part of #231